### PR TITLE
make buttons in optimizer hair tab behave like the tooltip says it will

### DIFF
--- a/Windows/Optimizers/HairTabCreator.cs
+++ b/Windows/Optimizers/HairTabCreator.cs
@@ -272,7 +272,7 @@ namespace VPM
                     if (skipNoDensity && hair.CurveDensity <= 0)
                         continue;
                     // Skip if the target density is greater than the current
-                    if (targetDensity > hair.CurveDensity)
+                    if (targetDensity >= hair.CurveDensity)
                         continue;
 
                     if (targetDensity == -1)

--- a/Windows/Optimizers/HairTabCreator.cs
+++ b/Windows/Optimizers/HairTabCreator.cs
@@ -271,7 +271,10 @@ namespace VPM
                     // Skip hair without density if checkbox is checked
                     if (skipNoDensity && hair.CurveDensity <= 0)
                         continue;
-                    
+                    // Skip if the target density is greater than the current
+                    if (targetDensity > hair.CurveDensity)
+                        continue;
+
                     if (targetDensity == -1)
                         hair.KeepUnchanged = true;
                     else if (targetDensity == 32)


### PR DESCRIPTION
Optimizer tab says

```
Reduce all hair to density X
(Only reduces density, never increases)
(Hair at or below X remains unchanged)
```

Current behavior

https://github.com/user-attachments/assets/674f3dc6-e8ee-4ff5-8299-2eb73f6b4b83

Fixed behavior

https://github.com/user-attachments/assets/0a23e58d-dcca-4268-ab21-ed94037861d0


resolves #14 