### PR TITLE
feat: support for BrowserAssist (BA) offloaded packages

### DIFF
--- a/Models/AppSettings.cs
+++ b/Models/AppSettings.cs
@@ -110,6 +110,10 @@ namespace VPM.Models
         // Package Downloader Settings
         private bool _enableAutoDownload = false;
 
+        // Integration Settings
+        private bool _browserAssistIntegration = false;
+        private bool _hasSeenBrowserAssistIntro = false;
+
         // App Update Settings
         private bool _checkForAppUpdates = true;
         
@@ -645,6 +649,18 @@ namespace VPM.Models
         {
             get => _enableAutoDownload;
             set => SetProperty(ref _enableAutoDownload, value);
+        }
+
+        public bool BrowserAssistIntegration
+        {
+            get => _browserAssistIntegration;
+            set => SetProperty(ref _browserAssistIntegration, value);
+        }
+
+        public bool HasSeenBrowserAssistIntro
+        {
+            get => _hasSeenBrowserAssistIntro;
+            set => SetProperty(ref _hasSeenBrowserAssistIntro, value);
         }
 
         public bool CheckForAppUpdates

--- a/Properties/launchSettings.json
+++ b/Properties/launchSettings.json
@@ -1,8 +1,7 @@
 {
   "profiles": {
     "VPM": {
-      "commandName": "Project",
-      "workingDirectory": "C:\\Users\\user\\Documents\\GitHub\\VPM\\.build"
+      "commandName": "Project"
     }
   }
 }

--- a/Services/BrowserAssistService.cs
+++ b/Services/BrowserAssistService.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text.Json;
+
+namespace VPM.Services
+{
+    public static class BrowserAssistService
+    {
+        private const string BaPluginDataPath = "Saves\\PluginData\\JayJayWon\\BrowserAssist";
+        private static readonly string[] ThumbnailExtensions = { ".jpg", ".png", ".jpeg" };
+
+        public static string GetOffloadedVarsFolder(string vamRoot)
+            => Path.Combine(vamRoot, BaPluginDataPath, "OffloadedVARs");
+
+        public static bool IsPathInOffloadedVars(string filePath, string offloadedVarsFolder)
+        {
+            if (string.IsNullOrEmpty(filePath) || string.IsNullOrEmpty(offloadedVarsFolder))
+                return false;
+
+            try
+            {
+                var fullFile = Path.GetFullPath(filePath);
+                var fullFolder = Path.GetFullPath(offloadedVarsFolder).TrimEnd(Path.DirectorySeparatorChar)
+                                 + Path.DirectorySeparatorChar;
+                return fullFile.StartsWith(fullFolder, StringComparison.OrdinalIgnoreCase);
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[BA] Failed to validate path containment: {ex.Message}");
+                return false;
+            }
+        }
+
+        public static string GetVarMetaCacheFolder(string vamRoot)
+            => Path.Combine(vamRoot, BaPluginDataPath, "DependencyCache", "VARs");
+
+        public static string GetVarThumbnailCacheFolder(string vamRoot)
+            => Path.Combine(vamRoot, BaPluginDataPath, "DependencyCache", "VARThumbnails");
+
+        public static bool IsInstalled(string vamRoot)
+            => Directory.Exists(GetOffloadedVarsFolder(vamRoot));
+
+        public static string GetSettingsFilePath(string vamRoot)
+            => Path.Combine(vamRoot, BaPluginDataPath, "BASettings.cfg");
+
+        // Returns true if BA's built-in VAR manager is active.
+        // When true, VPM must not move packages - BA owns the load/unload lifecycle.
+        public static bool IsVarManagementEnabled(string vamRoot)
+        {
+            string settingsPath = GetSettingsFilePath(vamRoot);
+            if (!File.Exists(settingsPath))
+                return false;
+
+            try
+            {
+                string json = File.ReadAllText(settingsPath);
+                using var doc = JsonDocument.Parse(json);
+                if (doc.RootElement.TryGetProperty("VARMgmgtSettings", out var varMgmt) &&
+                    varMgmt.TryGetProperty("varMgmntEnabled", out var enabled))
+                {
+                    // BA stores booleans as JSON strings: "true" / "false"
+                    return string.Equals(enabled.GetString(), "true", StringComparison.OrdinalIgnoreCase);
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[BA] Failed to read BASettings.cfg: {ex.Message}");
+            }
+
+            return false;
+        }
+
+        // varFilename can be "Creator.Package.Version.var" or "Creator.Package.Version"
+        public static void CleanCacheForPackage(string vamRoot, string varFilename)
+        {
+            string varName = varFilename.EndsWith(".var", StringComparison.OrdinalIgnoreCase)
+                ? varFilename[..^4]
+                : varFilename;
+
+            try
+            {
+                string metaPath = Path.Combine(GetVarMetaCacheFolder(vamRoot), varName + ".meta");
+                if (File.Exists(metaPath))
+                {
+                    File.Delete(metaPath);
+                    Debug.WriteLine($"[BA] Deleted meta cache: {metaPath}");
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[BA] Failed to delete meta cache for {varName}: {ex.Message}");
+            }
+
+            try
+            {
+                string thumbDir = Path.Combine(GetVarThumbnailCacheFolder(vamRoot), varName);
+                if (Directory.Exists(thumbDir))
+                {
+                    Directory.Delete(thumbDir, recursive: true);
+                    Debug.WriteLine($"[BA] Deleted thumbnail dir: {thumbDir}");
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[BA] Failed to delete thumbnail dir for {varName}: {ex.Message}");
+            }
+
+            // Also check for flat image files alongside the thumbnail dirs
+            string thumbBase = Path.Combine(GetVarThumbnailCacheFolder(vamRoot), varName);
+            foreach (string ext in ThumbnailExtensions)
+            {
+                try
+                {
+                    string flatFile = thumbBase + ext;
+                    if (File.Exists(flatFile))
+                    {
+                        File.Delete(flatFile);
+                        Debug.WriteLine($"[BA] Deleted flat thumbnail: {flatFile}");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine($"[BA] Failed to delete flat thumbnail {varName}{ext}: {ex.Message}");
+                }
+            }
+        }
+
+        // Deletes the {varFilePath}.json companion sidecar left by BA when it offloads a VAR
+        public static void DeleteCompanionJson(string varFilePath)
+        {
+            string companionPath = varFilePath + ".json";
+            try
+            {
+                if (File.Exists(companionPath))
+                {
+                    File.Delete(companionPath);
+                    Debug.WriteLine($"[BA] Deleted companion JSON: {companionPath}");
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[BA] Failed to delete companion JSON for {varFilePath}: {ex.Message}");
+            }
+        }
+    }
+}

--- a/Services/PackageFileManager.cs
+++ b/Services/PackageFileManager.cs
@@ -50,6 +50,25 @@ namespace VPM.Services
         private readonly Dictionary<string, (int fileCount, long lastWriteTicks)> _statusIndexDirectorySignatures = new Dictionary<string, (int, long)>(StringComparer.OrdinalIgnoreCase);
 
 
+        // Integration flags
+        private bool _browserAssistIntegration;
+        public bool BrowserAssistIntegration
+        {
+            get => _browserAssistIntegration;
+            set
+            {
+                if (_browserAssistIntegration != value)
+                {
+                    _browserAssistIntegration = value;
+                    // Status index includes/excludes OffloadedVARs based on this flag
+                    lock (_statusIndexLock)
+                    {
+                        _statusIndexBuilt = false;
+                    }
+                }
+            }
+        }
+
         // Disposal tracking
         private bool _disposed;
         
@@ -897,12 +916,41 @@ namespace VPM.Services
                 var (moved, moveError) = await TryFastRenameMoveAsync(sourceInfo, sourcePath, destinationPath, fastAttempts);
                 if (moved)
                 {
+                    CleanupBrowserAssistCacheIfOffloaded(sourcePath);
                     return (true, "");
                 }
             }
 
             // Fallback: robust copy+delete (works across volumes and when rename is blocked).
-            return await CopyDeleteFallbackAsync(sourceInfo, sourcePath, destinationPath, maxRetries);
+            var result = await CopyDeleteFallbackAsync(sourceInfo, sourcePath, destinationPath, maxRetries);
+            if (result.success)
+            {
+                CleanupBrowserAssistCacheIfOffloaded(sourcePath);
+            }
+            return result;
+        }
+
+        // BA stores companion .json files and caches alongside offloaded VARs; leaving them orphaned
+        // causes BA to re-download or show stale entries, so we clean up proactively after moves/deletes.
+        internal void CleanupBrowserAssistCacheIfOffloaded(string sourcePath)
+        {
+            if (!BrowserAssistIntegration)
+                return;
+
+            try
+            {
+                string offloadedVarsFolder = BrowserAssistService.GetOffloadedVarsFolder(_rootFolder);
+                if (string.IsNullOrEmpty(offloadedVarsFolder) ||
+                    !BrowserAssistService.IsPathInOffloadedVars(sourcePath, offloadedVarsFolder))
+                    return;
+
+                BrowserAssistService.DeleteCompanionJson(sourcePath);
+                BrowserAssistService.CleanCacheForPackage(_rootFolder, Path.GetFileName(sourcePath));
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"[BA] Cache cleanup failed for {sourcePath}: {ex.Message}");
+            }
         }
 
         private SemaphoreSlim GetPackageLock(string packageName)
@@ -953,9 +1001,16 @@ namespace VPM.Services
                 var depInfo = DependencyVersionInfo.Parse(packageName);
                 var baseName = depInfo.BaseName;
                 
-                // Determine the best version available across BOTH folders
+                // Determine the best version available across all known locations,
+                // including OffloadedVARs when BA integration is active.
                 string targetFile;
-                var searchDirs = new[] { _addonPackagesFolder, _allPackagesFolder };
+                string offloadedVarsFolder = BrowserAssistIntegration
+                    ? BrowserAssistService.GetOffloadedVarsFolder(_rootFolder)
+                    : null;
+                var searchDirsList = new List<string> { _addonPackagesFolder, _allPackagesFolder };
+                if (!string.IsNullOrEmpty(offloadedVarsFolder) && Directory.Exists(offloadedVarsFolder))
+                    searchDirsList.Add(offloadedVarsFolder);
+                var searchDirs = searchDirsList.ToArray();
                 
                 if (depInfo.VersionType == DependencyVersionType.Exact)
                 {
@@ -974,6 +1029,23 @@ namespace VPM.Services
                 if (string.IsNullOrEmpty(targetFile))
                 {
                     targetFile = FindExactPackagePath(packageName, searchDirs);
+                }
+
+                // Block the move if BA's VAR manager owns this package
+                if (!string.IsNullOrEmpty(targetFile) &&
+                    !string.IsNullOrEmpty(offloadedVarsFolder) &&
+                    BrowserAssistService.IsPathInOffloadedVars(targetFile, offloadedVarsFolder) &&
+                    BrowserAssistService.IsVarManagementEnabled(_rootFolder))
+                {
+                    var baErrorMsg = $"Disabled while BrowserAssist is managing packages.";
+                    OperationCompleted?.Invoke(this, new PackageOperationEventArgs
+                    {
+                        PackageName = packageName,
+                        Operation = "Load",
+                        Success = false,
+                        ErrorMessage = baErrorMsg
+                    });
+                    return (false, baErrorMsg, null);
                 }
 
                 if (string.IsNullOrEmpty(targetFile))
@@ -1796,45 +1868,89 @@ namespace VPM.Services
                     }
                 }
                 
+                // Scan BrowserAssist OffloadedVARs (Available packages not in AddonPackages or AllPackages)
+                if (BrowserAssistIntegration)
+                {
+                    var offloadedVarsFolder = BrowserAssistService.GetOffloadedVarsFolder(_rootFolder);
+                    if (Directory.Exists(offloadedVarsFolder))
+                    {
+                        var offloadedFiles = SymlinkSafeFileSystem.EnumerateFilesSafe(offloadedVarsFolder, "*.var", true);
+                        foreach (var file in offloadedFiles)
+                        {
+                            var filename = Path.GetFileNameWithoutExtension(file);
+                            var fullPackageName = ExtractFullPackageNameFromFilename(filename);
+                            if (!string.IsNullOrEmpty(fullPackageName))
+                            {
+                                _packageStatusIndex.TryAdd(fullPackageName, "Available");
+                                var depInfo = DependencyVersionInfo.Parse(fullPackageName);
+                                _packageStatusIndex.TryAdd(depInfo.BaseName, "Available");
+                            }
+                        }
+                    }
+                }
+
                 // Update directory signatures for next check
                 UpdateDirectorySignatures();
                 _statusIndexBuilt = true;
             }
         }
-        
+
+        private string[] GetStatusIndexDirectories()
+        {
+            var dirs = new[] { _addonPackagesFolder, _allPackagesFolder, _archivedPackagesFolder };
+            if (!BrowserAssistIntegration)
+                return dirs;
+
+            var offloadedFolder = BrowserAssistService.GetOffloadedVarsFolder(_rootFolder);
+            if (string.IsNullOrEmpty(offloadedFolder))
+                return dirs;
+
+            return new[] { _addonPackagesFolder, _allPackagesFolder, _archivedPackagesFolder, offloadedFolder };
+        }
+
         /// <summary>
         /// Checks if any package directories have changed since last scan
         /// </summary>
         private bool HasDirectoriesChanged()
         {
-            var directories = new[] { _addonPackagesFolder, _allPackagesFolder, _archivedPackagesFolder };
-            
+            var directories = GetStatusIndexDirectories();
+
             foreach (var dir in directories)
             {
                 if (!Directory.Exists(dir))
                     continue;
-                
+
                 var dirInfo = new DirectoryInfo(dir);
-                var currentSignature = (SymlinkSafeFileSystem.EnumerateFilesSafe(dir, "*.var", true).Count(), 
+                var currentSignature = (SymlinkSafeFileSystem.EnumerateFilesSafe(dir, "*.var", true).Count(),
                                        dirInfo.LastWriteTimeUtc.Ticks);
-                
-                if (!_statusIndexDirectorySignatures.TryGetValue(dir, out var lastSignature) || 
+
+                if (!_statusIndexDirectorySignatures.TryGetValue(dir, out var lastSignature) ||
                     lastSignature != currentSignature)
                 {
                     return true;
                 }
             }
-            
+
             return false;
         }
-        
+
         /// <summary>
         /// Updates directory signatures for change detection
         /// </summary>
         private void UpdateDirectorySignatures()
         {
-            var directories = new[] { _addonPackagesFolder, _allPackagesFolder, _archivedPackagesFolder };
-            
+            var directories = GetStatusIndexDirectories();
+            var directorySet = new HashSet<string>(directories, StringComparer.OrdinalIgnoreCase);
+
+            // Remove stale entries no longer in the tracking list
+            var staleKeys = _statusIndexDirectorySignatures.Keys
+                    .Where(k => !directorySet.Contains(k))
+                    .ToList();
+                foreach (var key in staleKeys)
+                {
+                    _statusIndexDirectorySignatures.Remove(key);
+                }
+
             foreach (var dir in directories)
             {
                 if (!Directory.Exists(dir))

--- a/Services/PackageManager.cs
+++ b/Services/PackageManager.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Buffers;
+using System.Diagnostics;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -1142,7 +1143,7 @@ namespace VPM.Services
             return results.ToDictionary(kvp => kvp.Key, kvp => kvp.Value, StringComparer.OrdinalIgnoreCase);
         }
 
-        public async Task<(List<string> installed, List<string> available)> ScanVarFilesAsync(string installedFolder, string allPackagesFolder)
+        public async Task<(List<string> installed, List<string> available)> ScanVarFilesAsync(string installedFolder, string allPackagesFolder, bool enableBrowserAssistIntegration = false)
         {
             var installed = new List<string>();
             var available = new List<string>();
@@ -1211,6 +1212,30 @@ namespace VPM.Services
                 }));
             }
 
+            // Scan BrowserAssist OffloadedVARs - VARs the BA plugin has moved out of AddonPackages.
+            // Treat as Available so they satisfy dependency checks and appear in the UI.
+            string offloadedVarsFolder = enableBrowserAssistIntegration
+                ? BrowserAssistService.GetOffloadedVarsFolder(rootFolder)
+                : null;
+            if (offloadedVarsFolder != null && Directory.Exists(offloadedVarsFolder))
+            {
+                scanTasks.Add(Task.Run(() =>
+                {
+                    try
+                    {
+                        var files = SymlinkSafeFileSystem.EnumerateFilesSafe(offloadedVarsFolder, "*.var", true);
+                        lock (available)
+                        {
+                            available.AddRange(files);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Debug.WriteLine($"[BA] OffloadedVARs scan failed: {ex.Message}");
+                    }
+                }));
+            }
+
             // Wait for all scanning tasks to complete
             await Task.WhenAll(scanTasks);
 
@@ -1221,11 +1246,12 @@ namespace VPM.Services
         /// Scans VAR files including external destinations
         /// </summary>
         public async Task<(List<string> installed, List<string> available, Dictionary<string, List<string>> external)> ScanVarFilesWithExternalAsync(
-            string installedFolder, 
-            string allPackagesFolder, 
-            List<MoveToDestination> externalDestinations)
+            string installedFolder,
+            string allPackagesFolder,
+            List<MoveToDestination> externalDestinations,
+            bool enableBrowserAssistIntegration = false)
         {
-            var (installed, available) = await ScanVarFilesAsync(installedFolder, allPackagesFolder);
+            var (installed, available) = await ScanVarFilesAsync(installedFolder, allPackagesFolder, enableBrowserAssistIntegration);
             var external = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
 
             if (externalDestinations == null || externalDestinations.Count == 0)

--- a/Windows/BrowserAssistSetupDialog.xaml
+++ b/Windows/BrowserAssistSetupDialog.xaml
@@ -1,0 +1,249 @@
+<Window x:Class="VPM.BrowserAssistSetupDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="BrowserAssist Integration"
+        SizeToContent="Height"
+        Width="640"
+        MaxHeight="800"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="NoResize"
+        Background="Transparent"
+        WindowStyle="None"
+        AllowsTransparency="True"
+        ShowInTaskbar="False"
+        Topmost="True">
+
+    <Window.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="MainWindowStyles.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+
+            <Style x:Key="DialogButton" TargetType="Button">
+                <Setter Property="Background" Value="{DynamicResource ButtonBackgroundBrush}"/>
+                <Setter Property="Foreground" Value="{DynamicResource TextBrush}"/>
+                <Setter Property="BorderBrush" Value="{DynamicResource ControlBorderBrush}"/>
+                <Setter Property="BorderThickness" Value="1"/>
+                <Setter Property="Padding" Value="20,10"/>
+                <Setter Property="FontSize" Value="13"/>
+                <Setter Property="Cursor" Value="Hand"/>
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="Button">
+                            <Border Background="{TemplateBinding Background}"
+                                    BorderBrush="{TemplateBinding BorderBrush}"
+                                    BorderThickness="{TemplateBinding BorderThickness}"
+                                    CornerRadius="4"
+                                    Padding="{TemplateBinding Padding}">
+                                <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                            </Border>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+                <Style.Triggers>
+                    <Trigger Property="IsMouseOver" Value="True">
+                        <Setter Property="Background" Value="{DynamicResource ButtonHoverBrush}"/>
+                        <Setter Property="BorderBrush" Value="#FF0078D7"/>
+                    </Trigger>
+                </Style.Triggers>
+            </Style>
+
+            <Style x:Key="PrimaryButton" TargetType="Button">
+                <Setter Property="Background" Value="#0078D4"/>
+                <Setter Property="Foreground" Value="White"/>
+                <Setter Property="BorderThickness" Value="0"/>
+                <Setter Property="Padding" Value="20,10"/>
+                <Setter Property="FontSize" Value="13"/>
+                <Setter Property="FontWeight" Value="SemiBold"/>
+                <Setter Property="Cursor" Value="Hand"/>
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="Button">
+                            <Border Background="{TemplateBinding Background}"
+                                    CornerRadius="4"
+                                    Padding="{TemplateBinding Padding}">
+                                <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                            </Border>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+                <Style.Triggers>
+                    <Trigger Property="IsMouseOver" Value="True">
+                        <Setter Property="Background" Value="#005A9E"/>
+                    </Trigger>
+                </Style.Triggers>
+            </Style>
+
+            <Style x:Key="InfoCardStyle" TargetType="Border">
+                <Setter Property="Background" Value="{DynamicResource ControlBackgroundBrush}"/>
+                <Setter Property="BorderBrush" Value="{DynamicResource ControlBorderBrush}"/>
+                <Setter Property="BorderThickness" Value="1"/>
+                <Setter Property="CornerRadius" Value="8"/>
+                <Setter Property="Padding" Value="20"/>
+                <Setter Property="Margin" Value="0,0,0,12"/>
+            </Style>
+
+            <Style x:Key="BodyTextStyle" TargetType="TextBlock">
+                <Setter Property="Foreground" Value="{DynamicResource SecondaryTextBrush}"/>
+                <Setter Property="FontSize" Value="13"/>
+                <Setter Property="TextWrapping" Value="Wrap"/>
+                <Setter Property="LineHeight" Value="22"/>
+            </Style>
+
+            <Style x:Key="BulletStyle" TargetType="TextBlock">
+                <Setter Property="Foreground" Value="{DynamicResource SecondaryTextBrush}"/>
+                <Setter Property="FontSize" Value="13"/>
+                <Setter Property="Margin" Value="0,0,10,0"/>
+            </Style>
+
+            <Style x:Key="SectionHeadingStyle" TargetType="TextBlock">
+                <Setter Property="Foreground" Value="{DynamicResource TextBrush}"/>
+                <Setter Property="FontSize" Value="14"/>
+                <Setter Property="FontWeight" Value="SemiBold"/>
+                <Setter Property="VerticalAlignment" Value="Center"/>
+            </Style>
+        </ResourceDictionary>
+    </Window.Resources>
+
+    <Border BorderBrush="{DynamicResource ControlBorderBrush}" BorderThickness="1" CornerRadius="10" Background="{DynamicResource WindowBackgroundBrush}">
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+
+            <!-- Header -->
+            <Border Grid.Row="0" Background="#0078D4" CornerRadius="8,8,0,0" MouseLeftButtonDown="TitleBar_MouseLeftButtonDown">
+                <Grid>
+                    <StackPanel Margin="24,20,50,20">
+                        <StackPanel Orientation="Horizontal">
+                            <Path Data="M19.333,7.667v-4h-4V1h-2v2.667h-2.667V1h-2v2.667H4.667v4c0,1.556,1.076,2.852,2.5,3.354v7.312  L5.111,20.39l1.886,1.886L9.333,19.94v-9.287c1.424-0.501,2.5-1.798,2.5-3.354h2v3.313c0,1.556,1.076,2.852,2.5,3.354v5.368  l2.056-2.056L19.333,7.667z M8.667,10.667c-1.103,0-2-0.897-2-2V5.667h4v3C10.667,9.769,9.769,10.667,8.667,10.667z M17.333,7.667  c-1.103,0-2-0.897-2-2V5.667h2V7.667z"
+                                  Fill="White" Width="20" Height="20" Stretch="Uniform" Margin="0,0,12,0" VerticalAlignment="Center"/>
+                            <TextBlock Text="BrowserAssist Integration" Foreground="White" FontWeight="Bold" FontSize="20" VerticalAlignment="Center"/>
+                        </StackPanel>
+                        <TextBlock Text="Keep offloaded packages visible and dependencies accurate"
+                                   Foreground="#E0E0E0" FontSize="13" Margin="0,6,0,0"/>
+                    </StackPanel>
+
+                    <Button x:Name="CloseButton" Click="Cancel_Click" Width="36" Height="36"
+                            VerticalAlignment="Top" HorizontalAlignment="Right" Margin="0,8,8,0"
+                            Style="{StaticResource TitleBarCloseButtonStyle}">
+                        <Path Data="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                              Fill="White" Width="12" Height="12" Stretch="Uniform"/>
+                    </Button>
+                </Grid>
+            </Border>
+
+            <!-- Content -->
+            <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+                <StackPanel Margin="24,20,24,10">
+
+                    <!-- What remains enabled -->
+                    <Border Style="{StaticResource InfoCardStyle}" BorderBrush="#2E7D32">
+                        <StackPanel>
+                            <StackPanel Orientation="Horizontal" Margin="0,0,0,14">
+                                <Border Width="24" Height="24" CornerRadius="12" Background="#334CAF50" Margin="0,0,10,0" VerticalAlignment="Center">
+                                    <Path Data="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z" Fill="#4CAF50" Width="12" Height="12" Stretch="Uniform" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                </Border>
+                                <TextBlock Text="What remains enabled" Style="{StaticResource SectionHeadingStyle}"/>
+                            </StackPanel>
+                            <Grid Margin="34,0,0,0">
+                                <Grid.Resources>
+                                    <Style TargetType="TextBlock" BasedOn="{StaticResource BodyTextStyle}"/>
+                                </Grid.Resources>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="*"/>
+                                </Grid.ColumnDefinitions>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                </Grid.RowDefinitions>
+
+                                <TextBlock Grid.Row="0" Grid.Column="0" Text="•" Style="{StaticResource BulletStyle}"/>
+                                <TextBlock Grid.Row="0" Grid.Column="1" Text="Offloaded packages show up in your list as &quot;Available&quot;"/>
+
+                                <TextBlock Grid.Row="1" Grid.Column="0" Text="•" Style="{StaticResource BulletStyle}"/>
+                                <TextBlock Grid.Row="1" Grid.Column="1" Text="Dependency checks count offloaded packages"/>
+
+                                <TextBlock Grid.Row="2" Grid.Column="0" Text="•" Style="{StaticResource BulletStyle}"/>
+                                <TextBlock Grid.Row="2" Grid.Column="1" Text="BA's cache is cleaned up when you archive packages"/>
+
+                                <TextBlock Grid.Row="3" Grid.Column="0" Text="•" Style="{StaticResource BulletStyle}"/>
+                                <TextBlock Grid.Row="3" Grid.Column="1" Text="Optimization features work as normal, with the exception of dependency forcing"/>
+
+                                <TextBlock Grid.Row="4" Grid.Column="0" Text="•" Style="{StaticResource BulletStyle}"/>
+                                <TextBlock Grid.Row="4" Grid.Column="1" Text="Duplicate handling, a new column is visible after enabling the integration."/>
+                            </Grid>
+                        </StackPanel>
+                    </Border>
+
+                    <!-- What is disabled -->
+                    <Border Style="{StaticResource InfoCardStyle}" BorderBrush="#C62828">
+                        <StackPanel>
+                            <StackPanel Orientation="Horizontal" Margin="0,0,0,14">
+                                <Border Width="24" Height="24" CornerRadius="12" Background="#33F44336" Margin="0,0,10,0" VerticalAlignment="Center">
+                                    <Path Data="M12 2C6.48 2 2 6.48 2 12C2 17.52 6.48 22 12 22C17.52 22 22 17.52 22 12C22 6.48 17.52 2 12 2 Z M 12 13C11.45 13 11 12.55 11 12L11 8C11 7.45 11.45 7 12 7C12.55 7 13 7.45 13 8L13 12C13 12.55 12.55 13 12 13 Z M 13 17L11 17L11 15L13 15L13 17 Z" Fill="#F44336" Width="12" Height="12" Stretch="Uniform" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                </Border>
+                                <TextBlock Text="What is disabled" Style="{StaticResource SectionHeadingStyle}"/>
+                            </StackPanel>
+                            <Grid Margin="34,0,0,0">
+                                <Grid.Resources>
+                                    <Style TargetType="TextBlock" BasedOn="{StaticResource BodyTextStyle}"/>
+                                </Grid.Resources>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="*"/>
+                                </Grid.ColumnDefinitions>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                </Grid.RowDefinitions>
+
+                                <TextBlock Grid.Row="0" Grid.Column="0" Text="•" Style="{StaticResource BulletStyle}"/>
+                                <TextBlock Grid.Row="0" Grid.Column="1" Text="Moving packages that are handled by BA. Packages that are in AddonPackages can still be moved."/>
+
+                                <TextBlock Grid.Row="1" Grid.Column="0" Text="•" Style="{StaticResource BulletStyle}"/>
+                                <TextBlock Grid.Row="1" Grid.Column="1" Text="Dependency modifications in the optimizer are restricted"/>
+                            </Grid>
+                        </StackPanel>
+                    </Border>
+
+                    <!-- Why These Restrictions -->
+                    <Border Style="{StaticResource InfoCardStyle}" BorderBrush="#1565C0">
+                        <StackPanel>
+                            <StackPanel Orientation="Horizontal" Margin="0,0,0,12">
+                                <Border Width="24" Height="24" CornerRadius="12" Background="#332196F3" Margin="0,0,10,0" VerticalAlignment="Center">
+                                    <Path Data="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z" Fill="#2196F3" Width="12" Height="12" Stretch="Uniform" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                </Border>
+                                <TextBlock Text="Why these restrictions?" Style="{StaticResource SectionHeadingStyle}"/>
+                            </StackPanel>
+                            <TextBlock Foreground="{DynamicResource SecondaryTextBrush}" FontSize="13" TextWrapping="Wrap" LineHeight="20" Margin="34,0,0,0"
+                                       Text="VAR management is a delicate process, and with both VPM and BA managing packages by moving files around, it can lead to cache corruption in BA. This can cause errors and loaded looks or scenes to be malformed."/>
+                            <TextBlock Foreground="{DynamicResource SecondaryTextBrush}" FontSize="13" TextWrapping="Wrap" LineHeight="20" Margin="34,10,0,0"
+                                       Text="To prevent breaking your scenes and forcing you to run cache rescans in VaM, VPM gracefully steps back and operates in a safe 'read-only' mode for any package managed by BA."/>
+                        </StackPanel>
+                    </Border>
+
+                    <!-- Note -->
+                    <StackPanel Orientation="Horizontal" Margin="4,4,0,4">
+                        <Path Data="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z" Fill="{DynamicResource SecondaryTextBrush}" Width="14" Height="14" Stretch="Uniform" VerticalAlignment="Top" Margin="0,2,8,0"/>
+                        <TextBlock Foreground="{DynamicResource SecondaryTextBrush}" FontSize="12.5" TextWrapping="Wrap" VerticalAlignment="Center"
+                                   Text="Scanning your offloaded folder may take a moment depending on the number of packages. The application may become unresponsive, this is completely normal."/>
+                    </StackPanel>
+                </StackPanel>
+            </ScrollViewer>
+
+            <!-- Footer -->
+            <Border Grid.Row="2" Background="{DynamicResource ControlBackgroundBrush}" BorderBrush="{DynamicResource ControlBorderBrush}" BorderThickness="0,1,0,0" CornerRadius="0,0,8,8" Padding="24,16">
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                    <Button Content="Cancel" Click="Cancel_Click" IsCancel="True" Style="{StaticResource DialogButton}" Margin="0,0,12,0" MinWidth="100"/>
+                    <Button Content="Enable Integration" Click="Confirm_Click" IsDefault="True" Style="{StaticResource PrimaryButton}" MinWidth="160"/>
+                </StackPanel>
+            </Border>
+        </Grid>
+    </Border>
+</Window>

--- a/Windows/BrowserAssistSetupDialog.xaml
+++ b/Windows/BrowserAssistSetupDialog.xaml
@@ -4,7 +4,7 @@
         Title="BrowserAssist Integration"
         SizeToContent="Height"
         Width="640"
-        MaxHeight="800"
+        MaxHeight="860"
         WindowStartupLocation="CenterOwner"
         ResizeMode="NoResize"
         Background="Transparent"
@@ -161,6 +161,7 @@
                                     <RowDefinition Height="Auto"/>
                                     <RowDefinition Height="Auto"/>
                                     <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
                                 </Grid.RowDefinitions>
 
                                 <TextBlock Grid.Row="0" Grid.Column="0" Text="•" Style="{StaticResource BulletStyle}"/>
@@ -229,11 +230,11 @@
                     </Border>
 
                     <!-- Note -->
-                    <StackPanel Orientation="Horizontal" Margin="4,4,0,4">
-                        <Path Data="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z" Fill="{DynamicResource SecondaryTextBrush}" Width="14" Height="14" Stretch="Uniform" VerticalAlignment="Top" Margin="0,2,8,0"/>
+                    <DockPanel Margin="4,4,0,4">
+                        <Path DockPanel.Dock="Left" Data="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z" Fill="{DynamicResource SecondaryTextBrush}" Width="14" Height="14" Stretch="Uniform" VerticalAlignment="Top" Margin="0,2,8,0"/>
                         <TextBlock Foreground="{DynamicResource SecondaryTextBrush}" FontSize="12.5" TextWrapping="Wrap" VerticalAlignment="Center"
                                    Text="Scanning your offloaded folder may take a moment depending on the number of packages. The application may become unresponsive, this is completely normal."/>
-                    </StackPanel>
+                    </DockPanel>
                 </StackPanel>
             </ScrollViewer>
 

--- a/Windows/BrowserAssistSetupDialog.xaml.cs
+++ b/Windows/BrowserAssistSetupDialog.xaml.cs
@@ -1,0 +1,35 @@
+using System.Windows;
+using System.Windows.Input;
+using VPM.Services;
+
+namespace VPM
+{
+    public partial class BrowserAssistSetupDialog : Window
+    {
+        public bool Confirmed { get; private set; }
+
+        public BrowserAssistSetupDialog()
+        {
+            InitializeComponent();
+            Loaded += (s, e) => DarkTitleBarHelper.Apply(this);
+        }
+
+        private void TitleBar_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            if (e.ButtonState == MouseButtonState.Pressed)
+                DragMove();
+        }
+
+        private void Confirm_Click(object sender, RoutedEventArgs e)
+        {
+            Confirmed = true;
+            Close();
+        }
+
+        private void Cancel_Click(object sender, RoutedEventArgs e)
+        {
+            Confirmed = false;
+            Close();
+        }
+    }
+}

--- a/Windows/DuplicateManagementWindow.xaml
+++ b/Windows/DuplicateManagementWindow.xaml
@@ -93,6 +93,37 @@
             </Setter>
         </Style>
 
+        <!-- CheckBox Style for OffloadedVars/BA (Purple) -->
+        <Style x:Key="OffloadedVarsCheckBoxStyle" TargetType="CheckBox">
+            <Setter Property="Foreground" Value="#E0E0E0"/>
+            <Setter Property="HorizontalAlignment" Value="Center"/>
+            <Setter Property="VerticalAlignment" Value="Center"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="CheckBox">
+                        <Grid Background="Transparent">
+                            <Ellipse x:Name="OuterCircle" Width="24" Height="24"
+                                     Stroke="#9C27B0" StrokeThickness="2" Fill="Transparent"/>
+                            <Ellipse x:Name="InnerCircle" Width="14" Height="14"
+                                     Fill="#9C27B0" Visibility="Collapsed"/>
+                        </Grid>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsChecked" Value="True">
+                                <Setter TargetName="InnerCircle" Property="Visibility" Value="Visible"/>
+                            </Trigger>
+                            <Trigger Property="IsEnabled" Value="False">
+                                <Setter TargetName="OuterCircle" Property="Opacity" Value="0.3"/>
+                                <Setter TargetName="InnerCircle" Property="Opacity" Value="0.3"/>
+                            </Trigger>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="OuterCircle" Property="StrokeThickness" Value="3"/>
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
         <!-- CheckBox Style for External (Orange) -->
         <Style x:Key="ExternalCheckBoxStyle" TargetType="CheckBox">
             <Setter Property="Foreground" Value="#E0E0E0"/>
@@ -267,6 +298,25 @@
                             <CheckBox Style="{StaticResource ExternalCheckBoxStyle}"
                                       IsChecked="{Binding KeepInExternal, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                       IsEnabled="{Binding ExistsInExternal}"/>
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
+
+                <!-- OffloadedVars (BA) Column - hidden when BA integration is not active -->
+                <DataGridTemplateColumn x:Name="OffloadedVarsColumn" Width="160" Visibility="Collapsed">
+                    <DataGridTemplateColumn.Header>
+                        <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
+                            <TextBlock Text="OffloadedVars (BA)" FontWeight="SemiBold"/>
+                            <Button x:Name="KeepOffloadedVarsButton" Content="Keep All" 
+                                    Margin="0,5,0,0" Padding="8,4" FontSize="11"
+                                    Click="KeepOffloadedVars_Click"/>
+                        </StackPanel>
+                    </DataGridTemplateColumn.Header>
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate>
+                            <CheckBox Style="{StaticResource OffloadedVarsCheckBoxStyle}"
+                                      IsChecked="{Binding KeepInOffloadedVars, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                      IsEnabled="{Binding ExistsInOffloadedVars}"/>
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>

--- a/Windows/DuplicateManagementWindow.xaml.cs
+++ b/Windows/DuplicateManagementWindow.xaml.cs
@@ -24,6 +24,9 @@ namespace VPM
         private string _addonPackagesPath;
         private string _allPackagesPath;
         private List<MoveToDestination> _externalDestinations;
+        private string _offloadedVarsPath;
+        // Called after each file is moved or deleted so BA companion JSON and caches are cleaned up
+        private Action<string> _baCleanupCallback;
 
         // Drag selection fields
         private bool _duplicateDragging = false;
@@ -32,13 +35,18 @@ namespace VPM
         private System.Windows.Controls.CheckBox _duplicateDragStartCheckbox;
         private bool? _duplicateDragCheckState;
 
-        public DuplicateManagementWindow(List<PackageItem> duplicatePackages, string addonPackagesPath, string allPackagesPath, List<MoveToDestination> externalDestinations)
+        public DuplicateManagementWindow(List<PackageItem> duplicatePackages, string addonPackagesPath, string allPackagesPath, List<MoveToDestination> externalDestinations, Action<string> baCleanupCallback = null, string offloadedVarsPath = null)
         {
             InitializeComponent();
-            
+
             _addonPackagesPath = addonPackagesPath;
             _allPackagesPath = allPackagesPath;
             _externalDestinations = externalDestinations ?? new List<MoveToDestination>();
+            _baCleanupCallback = baCleanupCallback;
+            _offloadedVarsPath = offloadedVarsPath;
+
+            if (!string.IsNullOrEmpty(_offloadedVarsPath))
+                OffloadedVarsColumn.Visibility = Visibility.Visible;
             
             // Apply dark theme to window chrome
             try
@@ -63,12 +71,6 @@ namespace VPM
         {
             _duplicatePackages = new ObservableCollection<DuplicatePackageItem>();
 
-            
-            // Debug: Log all received packages
-            foreach (var pkg in packages)
-            {
-            }
-
             // Group incoming metadata by base package name first
             // Note: We don't filter by Status or DuplicateLocationCount here because the metadata
             // might be stale after a refresh. We'll rely on the filesystem scan to determine actual duplicates.
@@ -89,25 +91,16 @@ namespace VPM
                 var baseName = baseEntry.Key;
                 var metadataItems = baseEntry.Value;
 
-
                 // Gather actual file instances from disk for this base package
                 var fileInstances = new List<FileInstance>();
                 var addonInstances = GetPackageInstancesInAddonPackages(baseName);
                 var allInstances = GetPackageInstancesInAllPackages(baseName);
                 var externalInstances = GetPackageInstancesInExternalDestinations(baseName);
-                
-                
-                // Log all found files
-                foreach (var path in addonInstances)
-                {
-                }
-                foreach (var path in allInstances)
-                {
-                }
-                
+                var offloadedInstances = GetPackageInstancesInOffloadedVars(baseName);
                 AppendFileInstances(fileInstances, addonInstances, FileLocation.AddonPackages);
                 AppendFileInstances(fileInstances, allInstances, FileLocation.AllPackages);
                 AppendFileInstances(fileInstances, externalInstances, FileLocation.External);
+                AppendFileInstances(fileInstances, offloadedInstances, FileLocation.OffloadedVars);
 
                 if (fileInstances.Count == 0)
                 {
@@ -128,6 +121,7 @@ namespace VPM
                     var addonFileInstances = new List<FileInstance>();
                     var allFileInstances = new List<FileInstance>();
                     var externalFileInstances = new List<FileInstance>();
+                    var offloadedFileInstances = new List<FileInstance>();
                     foreach (var inst in instances)
                     {
                         if (inst.Location == FileLocation.AddonPackages)
@@ -136,29 +130,27 @@ namespace VPM
                             allFileInstances.Add(inst);
                         else if (inst.Location == FileLocation.External)
                             externalFileInstances.Add(inst);
+                        else if (inst.Location == FileLocation.OffloadedVars)
+                            offloadedFileInstances.Add(inst);
                     }
-                    
+
                     bool hasAddon = addonFileInstances.Count > 0;
                     bool hasAll = allFileInstances.Count > 0;
                     bool hasExternal = externalFileInstances.Count > 0;
+                    bool hasOffloaded = offloadedFileInstances.Count > 0;
                     int addonCount = addonFileInstances.Count;
                     int allCount = allFileInstances.Count;
                     int externalCount = externalFileInstances.Count;
+                    int offloadedCount = offloadedFileInstances.Count;
                     
-                    // Get file sizes for logging
-                    var fileSizes = instances.Select(f => f.FileSize).Distinct().ToList();
-                    var sizeInfo = fileSizes.Count > 1 ? $"sizes: {string.Join(", ", fileSizes)}" : $"size: {fileSizes.FirstOrDefault()}";
-                    
-
                     // We care about duplicates that exist in more than one location OR multiple times in the same location
-                    int locationCount = (hasAddon ? 1 : 0) + (hasAll ? 1 : 0) + (hasExternal ? 1 : 0);
-                    bool isDuplicate = locationCount > 1 || addonCount > 1 || allCount > 1 || externalCount > 1;
+                    int locationCount = (hasAddon ? 1 : 0) + (hasAll ? 1 : 0) + (hasExternal ? 1 : 0) + (hasOffloaded ? 1 : 0);
+                    bool isDuplicate = locationCount > 1 || addonCount > 1 || allCount > 1 || externalCount > 1 || offloadedCount > 1;
                     
                     if (!isDuplicate)
                     {
                         continue;
                     }
-                    
 
                     var displayName = Path.GetFileNameWithoutExtension(fileGroup.Key);
 
@@ -174,13 +166,14 @@ namespace VPM
                     var duplicateItem = new DuplicatePackageItem
                     {
                         PackageName = displayName,
-                        // Enable both checkboxes - user can choose to move to the other location
                         ExistsInAddonPackages = hasAddon,
                         ExistsInAllPackages = hasAll,
                         ExistsInExternal = hasExternal,
+                        ExistsInOffloadedVars = hasOffloaded,
                         KeepInAddonPackages = hasAddon,
                         KeepInAllPackages = !hasAddon && hasAll,
                         KeepInExternal = !hasAddon && !hasAll && hasExternal,
+                        KeepInOffloadedVars = !hasAddon && !hasAll && !hasExternal && hasOffloaded,
                         LoadedPackageItem = addonMetadata ?? allMetadata ?? metadataItems.FirstOrDefault(),
                         AvailablePackageItem = allMetadata ?? addonMetadata ?? metadataItems.FirstOrDefault(),
                         FileSizeBytes = maxFileSize
@@ -209,7 +202,8 @@ namespace VPM
         {
             AddonPackages,
             AllPackages,
-            External
+            External,
+            OffloadedVars
         }
 
         private readonly struct FileInstance
@@ -416,6 +410,22 @@ namespace VPM
             return instances;
         }
         
+        private List<string> GetPackageInstancesInOffloadedVars(string baseName)
+        {
+            var instances = new List<string>();
+            if (string.IsNullOrEmpty(_offloadedVarsPath) || !Directory.Exists(_offloadedVarsPath))
+                return instances;
+            try
+            {
+                var pattern = $"{baseName}.*.var";
+                var files = SymlinkSafeFileSystem.EnumerateFilesSafe(_offloadedVarsPath, pattern, true);
+                foreach (var file in files)
+                    instances.Add(file);
+            }
+            catch { }
+            return instances;
+        }
+
         /// <summary>
         /// Extract base package name from display name (Creator.PackageName without version)
         /// </summary>
@@ -494,9 +504,10 @@ namespace VPM
 
         private void DuplicateItem_PropertyChanged(object sender, PropertyChangedEventArgs e)
         {
-            if (e.PropertyName == nameof(DuplicatePackageItem.KeepInAddonPackages) || 
+            if (e.PropertyName == nameof(DuplicatePackageItem.KeepInAddonPackages) ||
                 e.PropertyName == nameof(DuplicatePackageItem.KeepInAllPackages) ||
-                e.PropertyName == nameof(DuplicatePackageItem.KeepInExternal))
+                e.PropertyName == nameof(DuplicatePackageItem.KeepInExternal) ||
+                e.PropertyName == nameof(DuplicatePackageItem.KeepInOffloadedVars))
             {
                 UpdateFixButtonCounter();
             }
@@ -506,11 +517,11 @@ namespace VPM
         {
             int deleteCount = 0;
             bool hasSelection = false;
-            
+
             foreach (var item in _duplicatePackages)
             {
-                // If both options are unchecked, this duplicate is excluded from processing
-                if (!item.KeepInAddonPackages && !item.KeepInAllPackages && !item.KeepInExternal)
+                // If no location is selected to keep, this duplicate is excluded from processing
+                if (!item.KeepInAddonPackages && !item.KeepInAllPackages && !item.KeepInExternal && !item.KeepInOffloadedVars)
                     continue;
 
                 hasSelection = true;
@@ -521,8 +532,10 @@ namespace VPM
                     deleteCount++;
                 if (item.ExistsInExternal && !item.KeepInExternal)
                     deleteCount++;
+                if (item.ExistsInOffloadedVars && !item.KeepInOffloadedVars)
+                    deleteCount++;
             }
-            
+
             FixDuplicatesButton.Content = $"Fix Duplicates ({deleteCount})";
             FixDuplicatesButton.IsEnabled = hasSelection;
         }
@@ -548,6 +561,7 @@ namespace VPM
                     item.KeepInAllPackages = true;
                     item.KeepInAddonPackages = false;
                     item.KeepInExternal = false;
+                    item.KeepInOffloadedVars = false;
                 }
             }
         }
@@ -561,6 +575,21 @@ namespace VPM
                     item.KeepInAddonPackages = true;
                     item.KeepInAllPackages = false;
                     item.KeepInExternal = false;
+                    item.KeepInOffloadedVars = false;
+                }
+            }
+        }
+
+        private void KeepOffloadedVars_Click(object sender, RoutedEventArgs e)
+        {
+            foreach (var item in _duplicatePackages)
+            {
+                if (item.ExistsInOffloadedVars)
+                {
+                    item.KeepInAddonPackages = false;
+                    item.KeepInAllPackages = false;
+                    item.KeepInExternal = false;
+                    item.KeepInOffloadedVars = true;
                 }
             }
         }
@@ -574,23 +603,23 @@ namespace VPM
             // PERFORMANCE FIX: Cache all disk I/O results upfront to avoid repeated filesystem scans
             // Previously: GetPackageInstances* called 2-4 times per package (O(n) disk scans each)
             // Now: Single scan per unique baseName, cached for reuse
-            var instanceCache = new Dictionary<string, (List<string> addon, List<string> all, List<string> external)>(StringComparer.OrdinalIgnoreCase);
-            
+            var instanceCache = new Dictionary<string, (List<string> addon, List<string> all, List<string> external, List<string> offloaded)>(StringComparer.OrdinalIgnoreCase);
+
             List<string> GetCachedAddonInstances(string baseName)
             {
                 if (!instanceCache.TryGetValue(baseName, out var cached))
                 {
-                    cached = (GetPackageInstancesInAddonPackages(baseName), GetPackageInstancesInAllPackages(baseName), GetPackageInstancesInExternalDestinations(baseName));
+                    cached = (GetPackageInstancesInAddonPackages(baseName), GetPackageInstancesInAllPackages(baseName), GetPackageInstancesInExternalDestinations(baseName), GetPackageInstancesInOffloadedVars(baseName));
                     instanceCache[baseName] = cached;
                 }
                 return cached.addon;
             }
-            
+
             List<string> GetCachedAllInstances(string baseName)
             {
                 if (!instanceCache.TryGetValue(baseName, out var cached))
                 {
-                    cached = (GetPackageInstancesInAddonPackages(baseName), GetPackageInstancesInAllPackages(baseName), GetPackageInstancesInExternalDestinations(baseName));
+                    cached = (GetPackageInstancesInAddonPackages(baseName), GetPackageInstancesInAllPackages(baseName), GetPackageInstancesInExternalDestinations(baseName), GetPackageInstancesInOffloadedVars(baseName));
                     instanceCache[baseName] = cached;
                 }
                 return cached.all;
@@ -600,10 +629,20 @@ namespace VPM
             {
                 if (!instanceCache.TryGetValue(baseName, out var cached))
                 {
-                    cached = (GetPackageInstancesInAddonPackages(baseName), GetPackageInstancesInAllPackages(baseName), GetPackageInstancesInExternalDestinations(baseName));
+                    cached = (GetPackageInstancesInAddonPackages(baseName), GetPackageInstancesInAllPackages(baseName), GetPackageInstancesInExternalDestinations(baseName), GetPackageInstancesInOffloadedVars(baseName));
                     instanceCache[baseName] = cached;
                 }
                 return cached.external;
+            }
+
+            List<string> GetCachedOffloadedInstances(string baseName)
+            {
+                if (!instanceCache.TryGetValue(baseName, out var cached))
+                {
+                    cached = (GetPackageInstancesInAddonPackages(baseName), GetPackageInstancesInAllPackages(baseName), GetPackageInstancesInExternalDestinations(baseName), GetPackageInstancesInOffloadedVars(baseName));
+                    instanceCache[baseName] = cached;
+                }
+                return cached.offloaded;
             }
             
             // First pass: identify packages that need subfolder selection
@@ -646,6 +685,17 @@ namespace VPM
                         packagesRequiringSelection.Add(item);
                     }
                 }
+                else if (item.KeepInOffloadedVars && !item.KeepInAddonPackages && !item.KeepInAllPackages && !item.KeepInExternal)
+                {
+                    var baseName = ExtractBasePackageName(item.PackageName);
+                    var offloadedInstances = GetCachedOffloadedInstances(baseName)
+                        .Where(path => Path.GetFileName(path).Equals(expectedFileName, StringComparison.OrdinalIgnoreCase))
+                        .ToList();
+                    if (offloadedInstances.Count > 1)
+                    {
+                        packagesRequiringSelection.Add(item);
+                    }
+                }
             }
             
             // Handle packages that require subfolder selection FIRST
@@ -659,13 +709,13 @@ namespace VPM
                 var expectedFileName = item.PackageName + ".var";
                 
                 if (item.KeepInAddonPackages)
-                {
                     instances = GetCachedAddonInstances(baseName);
-                }
+                else if (item.KeepInAllPackages)
+                    instances = GetCachedAllInstances(baseName);
+                else if (item.KeepInOffloadedVars)
+                    instances = GetCachedOffloadedInstances(baseName);
                 else
-                {
-                    instances = item.KeepInExternal ? GetCachedExternalInstances(baseName) : GetCachedAllInstances(baseName);
-                }
+                    instances = GetCachedExternalInstances(baseName);
                 
                 // Filter to only the specific version the user selected
                 instances = instances.Where(path => 
@@ -713,8 +763,11 @@ namespace VPM
                 var externalPackageInstances = GetCachedExternalInstances(baseName)
                     .Where(path => Path.GetFileName(path).Equals(expectedFileName, StringComparison.OrdinalIgnoreCase))
                     .ToList();
+                var offloadedPackageInstances = GetCachedOffloadedInstances(baseName)
+                    .Where(path => Path.GetFileName(path).Equals(expectedFileName, StringComparison.OrdinalIgnoreCase))
+                    .ToList();
 
-                if (!item.KeepInAddonPackages && !item.KeepInAllPackages && !item.KeepInExternal)
+                if (!item.KeepInAddonPackages && !item.KeepInAllPackages && !item.KeepInExternal && !item.KeepInOffloadedVars)
                 {
                     continue;
                 }
@@ -735,6 +788,10 @@ namespace VPM
                 else if (item.KeepInExternal && externalPackageInstances.Count > 0)
                 {
                     packagesToKeep.Add(externalPackageInstances[0]);
+                }
+                else if (item.KeepInOffloadedVars && offloadedPackageInstances.Count > 0)
+                {
+                    packagesToKeep.Add(offloadedPackageInstances[0]);
                 }
 
                 if (!item.KeepInAddonPackages)
@@ -762,6 +819,15 @@ namespace VPM
                 else if (selectedFilesToKeep.ContainsKey(item.PackageName))
                 {
                     packagesToDelete.AddRange(externalPackageInstances.Where(p => !string.Equals(p, selectedFilesToKeep[item.PackageName], StringComparison.OrdinalIgnoreCase)));
+                }
+
+                if (!item.KeepInOffloadedVars)
+                {
+                    packagesToDelete.AddRange(offloadedPackageInstances);
+                }
+                else if (selectedFilesToKeep.ContainsKey(item.PackageName))
+                {
+                    packagesToDelete.AddRange(offloadedPackageInstances.Where(p => !string.Equals(p, selectedFilesToKeep[item.PackageName], StringComparison.OrdinalIgnoreCase)));
                 }
             }
             
@@ -806,9 +872,10 @@ namespace VPM
                         // Verify it's a .var file before deletion (safety check)
                         if (Path.GetExtension(filePath).Equals(".var", StringComparison.OrdinalIgnoreCase))
                         {
+                            _baCleanupCallback?.Invoke(filePath);
                             File.Delete(filePath);
                             successCount++;
-                            
+
                             // Small delay to prevent UI freezing on large operations
                             if (successCount % 10 == 0)
                             {
@@ -959,6 +1026,7 @@ namespace VPM
                             }
                             
                             // Move the file
+                            _baCleanupCallback?.Invoke(sourcePath);
                             SymlinkSafeFileSystem.MoveFileSafe(sourcePath, destPath);
                             moveSuccessCount++;
                             
@@ -990,9 +1058,10 @@ namespace VPM
                         // Verify it's a .var file before deletion (safety check)
                         if (Path.GetExtension(filePath).Equals(".var", StringComparison.OrdinalIgnoreCase))
                         {
+                            _baCleanupCallback?.Invoke(filePath);
                             File.Delete(filePath);
                             deleteSuccessCount++;
-                            
+
                             // Small delay to prevent UI freezing on large operations
                             if (deleteSuccessCount % 10 == 0)
                             {
@@ -1212,9 +1281,11 @@ namespace VPM
         private bool _keepInAddonPackages;
         private bool _keepInAllPackages;
         private bool _keepInExternal;
+        private bool _keepInOffloadedVars;
         private bool _existsInAddonPackages;
         private bool _existsInAllPackages;
         private bool _existsInExternal;
+        private bool _existsInOffloadedVars;
         private long _fileSizeBytes;
         private bool _isUpdating;
 
@@ -1238,6 +1309,12 @@ namespace VPM
             set => SetField(ref _existsInExternal, value);
         }
 
+        public bool ExistsInOffloadedVars
+        {
+            get => _existsInOffloadedVars;
+            set => SetField(ref _existsInOffloadedVars, value);
+        }
+
         public bool KeepInAddonPackages
         {
             get => _keepInAddonPackages;
@@ -1256,6 +1333,7 @@ namespace VPM
                         _isUpdating = true;
                         KeepInAllPackages = false;
                         KeepInExternal = false;
+                        KeepInOffloadedVars = false;
                     }
                     finally
                     {
@@ -1283,6 +1361,7 @@ namespace VPM
                         _isUpdating = true;
                         KeepInAddonPackages = false;
                         KeepInExternal = false;
+                        KeepInOffloadedVars = false;
                     }
                     finally
                     {
@@ -1310,6 +1389,35 @@ namespace VPM
                         _isUpdating = true;
                         KeepInAddonPackages = false;
                         KeepInAllPackages = false;
+                        KeepInOffloadedVars = false;
+                    }
+                    finally
+                    {
+                        _isUpdating = false;
+                    }
+                }
+            }
+        }
+
+        public bool KeepInOffloadedVars
+        {
+            get => _keepInOffloadedVars;
+            set
+            {
+                if (!SetField(ref _keepInOffloadedVars, value))
+                    return;
+
+                if (_isUpdating)
+                    return;
+
+                if (value)
+                {
+                    try
+                    {
+                        _isUpdating = true;
+                        KeepInAddonPackages = false;
+                        KeepInAllPackages = false;
+                        KeepInExternal = false;
                     }
                     finally
                     {

--- a/Windows/MainWindow.EventHandlers.cs
+++ b/Windows/MainWindow.EventHandlers.cs
@@ -1512,6 +1512,57 @@ namespace VPM
             }
         }
 
+        private void ToggleBrowserAssistIntegration_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is not MenuItem menuItem)
+                return;
+
+            bool enabled = menuItem.IsChecked;
+
+            // Disabling never needs confirmation
+            if (!enabled)
+            {
+                _settingsManager.Settings.BrowserAssistIntegration = false;
+                if (_packageFileManager != null)
+                    _packageFileManager.BrowserAssistIntegration = false;
+                RefreshPackages();
+                return;
+            }
+
+            // Check if VAR management is enabled first
+            if (!Services.BrowserAssistService.IsVarManagementEnabled(_settingsManager.Settings.SelectedFolder))
+            {
+                CustomMessageBox.Show(
+                    "VAR Management is not enabled in BrowserAssist.\n\nThis integration is only useful if BrowserAssist is actively configured to manage your offloaded VARs.",
+                    "Integration Unavailable", 
+                    MessageBoxButton.OK, 
+                    MessageBoxImage.Information);
+                
+                menuItem.IsChecked = false;
+                return;
+            }
+
+            // First-time enable: show the setup dialog
+            if (!(_settingsManager.Settings.HasSeenBrowserAssistIntro))
+            {
+                var dialog = new BrowserAssistSetupDialog { Owner = this };
+                dialog.ShowDialog();
+
+                if (!dialog.Confirmed)
+                {
+                    menuItem.IsChecked = false;
+                    return;
+                }
+
+                _settingsManager.Settings.HasSeenBrowserAssistIntro = true;
+            }
+
+            _settingsManager.Settings.BrowserAssistIntegration = true;
+            if (_packageFileManager != null)
+                _packageFileManager.BrowserAssistIntegration = true;
+            RefreshPackages();
+        }
+
         private void About_Click(object sender, RoutedEventArgs e)
         {
             var aboutWindow = new AboutWindow
@@ -2497,9 +2548,8 @@ namespace VPM
                     .Where(p => p.Status == "Available")
                     .ToList();
 
-                if (selectedPackages.Count > 0)
+                if (selectedPackages.Count > 0 && LoadPackagesWithDepsButton.IsEnabled)
                 {
-                    // Trigger load with deps button click
                     LoadPackagesWithDepsButton.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
                     e.Handled = true;
                     // Restore focus to DataGrid cell after operation
@@ -2546,7 +2596,11 @@ namespace VPM
                         
                         if (status == "Available")
                         {
-                            // Trigger load button click
+                            if (!LoadPackagesButton.IsEnabled)
+                            {
+                                e.Handled = true;
+                                return;
+                            }
                             LoadPackagesButton.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
                             e.Handled = true;
                             // Restore focus to selected row in DataGrid after operation
@@ -4438,15 +4492,24 @@ namespace VPM
                 string addonPackagesPath = Path.Combine(_selectedFolder, "AddonPackages");
                 string allPackagesPath = Path.Combine(_selectedFolder, "AllPackages");
                 var externalDestinations = _settingsManager?.Settings?.MoveToDestinations;
-                
+
+                string offloadedVarsPath = null;
+                if (_settingsManager?.Settings?.BrowserAssistIntegration == true)
+                {
+                    var path = Services.BrowserAssistService.GetOffloadedVarsFolder(_selectedFolder);
+                    if (Directory.Exists(path)) offloadedVarsPath = path;
+                }
+
                 // Open the duplicate management window
-                var duplicateWindow = new DuplicateManagementWindow(duplicatePackages, addonPackagesPath, allPackagesPath, externalDestinations)
+                var duplicateWindow = new DuplicateManagementWindow(duplicatePackages, addonPackagesPath, allPackagesPath, externalDestinations,
+                    baCleanupCallback: _packageFileManager != null ? _packageFileManager.CleanupBrowserAssistCacheIfOffloaded : null,
+                    offloadedVarsPath: offloadedVarsPath)
                 {
                     Owner = this
                 };
-                
+
                 var result = duplicateWindow.ShowDialog();
-                
+
                 // If user fixed duplicates, refresh the package list
                 if (result == true)
                 {
@@ -4496,9 +4559,18 @@ namespace VPM
                 string addonPackagesPath = Path.Combine(_selectedFolder, "AddonPackages");
                 string allPackagesPath = Path.Combine(_selectedFolder, "AllPackages");
                 var externalDestinations = _settingsManager?.Settings?.MoveToDestinations;
-                
+
+                string offloadedVarsPath = null;
+                if (_settingsManager?.Settings?.BrowserAssistIntegration == true)
+                {
+                    var path = Services.BrowserAssistService.GetOffloadedVarsFolder(_selectedFolder);
+                    if (Directory.Exists(path)) offloadedVarsPath = path;
+                }
+
                 // Open the duplicate management window
-                var duplicateWindow = new DuplicateManagementWindow(duplicatePackages, addonPackagesPath, allPackagesPath, externalDestinations)
+                var duplicateWindow = new DuplicateManagementWindow(duplicatePackages, addonPackagesPath, allPackagesPath, externalDestinations,
+                    baCleanupCallback: _packageFileManager != null ? _packageFileManager.CleanupBrowserAssistCacheIfOffloaded : null,
+                    offloadedVarsPath: offloadedVarsPath)
                 {
                     Owner = this
                 };
@@ -6625,10 +6697,22 @@ namespace VPM
                         var hasAvailable = selectedPackages.Any(p => p.Status == "Available");
                         var hasExternal = selectedPackages.Any(p => p.IsExternal);
 
+                        bool baBlocks = (hasAvailable || hasExternal) && IsAnyPackageBaManaged(selectedPackages);
+
                         if (loadContextMenuItem != null)
                         {
                             loadContextMenuItem.Visibility = Visibility.Visible;
-                            loadContextMenuItem.IsEnabled = duplicateCount == 0 && (hasAvailable || hasExternal);
+                            if (baBlocks)
+                            {
+                                loadContextMenuItem.IsEnabled = false;
+                                loadContextMenuItem.ToolTip = "Disabled while BrowserAssist is managing packages";
+                                ToolTipService.SetShowOnDisabled(loadContextMenuItem, true);
+                            }
+                            else
+                            {
+                                loadContextMenuItem.IsEnabled = duplicateCount == 0 && (hasAvailable || hasExternal);
+                                loadContextMenuItem.ToolTip = null;
+                            }
                         }
                         if (unloadContextMenuItem != null)
                         {
@@ -6659,7 +6743,19 @@ namespace VPM
                 // Populate Move To submenu with configured destinations
                 if (moveToMenuItem != null)
                 {
-                    PopulateMoveToMenu(moveToMenuItem, isPackageMenu: true);
+                    var movePkgs = PackageDataGrid?.SelectedItems?.Cast<PackageItem>()?.ToList();
+                    if (movePkgs != null && movePkgs.Count > 0 && IsAnyPackageBaManaged(movePkgs))
+                    {
+                        moveToMenuItem.IsEnabled = false;
+                        moveToMenuItem.ToolTip = "Disabled while BrowserAssist is managing packages";
+                        ToolTipService.SetShowOnDisabled(moveToMenuItem, true);
+                    }
+                    else
+                    {
+                        moveToMenuItem.IsEnabled = true;
+                        moveToMenuItem.ToolTip = null;
+                        PopulateMoveToMenu(moveToMenuItem, isPackageMenu: true);
+                    }
                 }
 
                 // Populate Add to Playlist submenu with playlists
@@ -7735,6 +7831,13 @@ namespace VPM
             {
                 DarkMessageBox.Show("No packages selected.", "Move To",
                     MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
+
+            if (IsAnyPackageBaManaged(selectedPackages))
+            {
+                DarkMessageBox.Show("Disabled while BrowserAssist is managing packages.", "Move To",
+                    MessageBoxButton.OK, MessageBoxImage.Warning);
                 return;
             }
 

--- a/Windows/MainWindow.ImageManagement.cs
+++ b/Windows/MainWindow.ImageManagement.cs
@@ -1657,6 +1657,12 @@ namespace VPM
                         var packageItem = imageItem.PackageItem;
                         if (packageItem != null && _packageFileManager != null)
                         {
+                            if (_baVarManagementEnabled == true &&
+                                Services.BrowserAssistService.IsPathInOffloadedVars(
+                                    _packageManager?.PackageMetadata?.GetValueOrDefault(packageItem.MetadataKey ?? packageItem.Name)?.FilePath,
+                                    Services.BrowserAssistService.GetOffloadedVarsFolder(_selectedFolder)))
+                                return;
+
                             // Cancel any pending image loading operations to free up file handles
                             _imageLoadingCts?.Cancel();
                             _imageLoadingCts = new System.Threading.CancellationTokenSource();

--- a/Windows/MainWindow.PackageOperations.cs
+++ b/Windows/MainWindow.PackageOperations.cs
@@ -842,6 +842,14 @@ namespace VPM
             {
                 if (!EnsureVamFolderSelected()) return;
 
+                var parentPackages = PackageDataGrid?.SelectedItems?.Cast<PackageItem>()?.ToList();
+                if (parentPackages != null && parentPackages.Count > 0 && IsAnyPackageBaManaged(parentPackages))
+                {
+                    DarkMessageBox.Show("Loading dependencies is disabled while BrowserAssist is managing this package.", "BrowserAssist Integration",
+                        MessageBoxButton.OK, MessageBoxImage.Warning);
+                    return;
+                }
+
                 // Include Available, Outdated, Archived, and external dependencies (hex color status indicates external)
                 var selectedDependencies = DependenciesDataGrid.SelectedItems.Cast<DependencyItem>()
                     .Where(d => d.Status == "Available" || d.Status == "Outdated" || d.Status == "Archived" || (d.Status?.StartsWith("#") == true))
@@ -1485,6 +1493,32 @@ namespace VPM
         #region Button Bar Management
 
         /// <summary>
+        /// Returns true if any of the given packages are in BA's OffloadedVARs folder
+        /// and BA's VAR management is enabled, meaning VPM must not move them.
+        /// </summary>
+        private bool IsAnyPackageBaManaged(IEnumerable<PackageItem> packages)
+        {
+            if (_settingsManager?.Settings?.BrowserAssistIntegration != true)
+                return false;
+
+            string offloadedVarsFolder = Services.BrowserAssistService.GetOffloadedVarsFolder(_selectedFolder);
+            if (!System.IO.Directory.Exists(offloadedVarsFolder))
+                return false;
+
+            bool anyInOffloadedVars = packages
+                .Where(p => p.Status == "Available" || p.IsExternal)
+                .Any(p =>
+                {
+                    string key = !string.IsNullOrEmpty(p.MetadataKey) ? p.MetadataKey : p.Name;
+                    return _packageManager?.PackageMetadata?.TryGetValue(key, out var meta) == true
+                        && !string.IsNullOrEmpty(meta?.FilePath)
+                        && Services.BrowserAssistService.IsPathInOffloadedVars(meta.FilePath, offloadedVarsFolder);
+                });
+
+            return anyInOffloadedVars && (_baVarManagementEnabled ?? false);
+        }
+
+        /// <summary>
         /// Updates the visibility and state of buttons in the package button bar based on selected packages
         /// </summary>
         private void UpdatePackageButtonBar()
@@ -1607,6 +1641,11 @@ namespace VPM
                 // Show Load +Deps button if any packages are Available or External OR if there are available dependencies
                 LoadPackagesWithDepsButton.Visibility = (hasAvailable || hasExternal || hasAvailableDependencies) ? Visibility.Visible : Visibility.Collapsed;
 
+                bool baBlocksLoad = (hasAvailable || hasExternal) && IsAnyPackageBaManaged(selectedPackages);
+
+                LoadPackagesButton.IsEnabled = !baBlocksLoad;
+                LoadPackagesWithDepsButton.IsEnabled = !baBlocksLoad;
+
                 // Check if all selected packages have the same normalized status (for keyboard shortcut hint)
                 // For EXTERNAL packages, treat them as "Available" for status comparison
                 var normalizedStatuses = selectedPackages.Select(p => p.IsExternal ? "Available" : p.Status).Distinct().ToList();
@@ -1619,8 +1658,15 @@ namespace VPM
                     // Count both available and external packages for load operations
                     var loadableCount = selectedPackages.Count(p => p.Status == "Available" || p.IsExternal);
 
+                    if (baBlocksLoad)
+                    {
+                        LoadPackagesButton.Content = "📥 Load";
+                        LoadPackagesButton.ToolTip = "Disabled while BrowserAssist is managing packages";
+                        LoadPackagesWithDepsButton.Content = "📥 Load +Deps";
+                        LoadPackagesWithDepsButton.ToolTip = "Disabled while BrowserAssist is managing packages";
+                    }
                     // Show keyboard shortcut if all selected items have same normalized status
-                    if (allSameStatus && normalizedStatuses[0] == "Available")
+                    else if (allSameStatus && normalizedStatuses[0] == "Available")
                     {
                         LoadPackagesButton.Content = loadableCount == 1 ? "📥 Load (Space)" : $"📥 Load ({loadableCount}) (Ctrl+Space)";
                         LoadPackagesButton.ToolTip = loadableCount == 1 ? "Load selected package" : $"Load {loadableCount} selected packages";
@@ -1757,6 +1803,14 @@ namespace VPM
                 // Show Load button if any dependencies are Available, Outdated, Archived, or External
                 // Outdated/Archived means an old version exists but can still be loaded
                 LoadDependenciesButton.Visibility = (hasAvailable || hasOutdated || hasArchived || hasExternal) ? Visibility.Visible : Visibility.Collapsed;
+
+                // Disable Load button when BrowserAssist owns the parent package
+                var parentPackagesForDeps = PackageDataGrid?.SelectedItems?.Cast<PackageItem>()?.ToList();
+                bool baBlocksDepsLoad = parentPackagesForDeps != null && parentPackagesForDeps.Count > 0 && IsAnyPackageBaManaged(parentPackagesForDeps);
+                LoadDependenciesButton.IsEnabled = !baBlocksDepsLoad;
+                LoadDependenciesButton.ToolTip = baBlocksDepsLoad
+                    ? "Disabled while BrowserAssist is managing this package"
+                    : "Load selected dependencies";
 
                 // Show Unload button if any dependencies are Loaded
                 UnloadDependenciesButton.Visibility = hasLoaded ? Visibility.Visible : Visibility.Collapsed;
@@ -2267,6 +2321,9 @@ namespace VPM
                             }
 
                             Interlocked.Increment(ref movedCount);
+
+                            // Clean up BA companion JSON and thumbnail cache if the file came from OffloadedVARs
+                            _packageFileManager?.CleanupBrowserAssistCacheIfOffloaded(sourceFile);
                         }
                     }
                     catch (Exception ex)
@@ -2278,7 +2335,7 @@ namespace VPM
                         }
                     }
                 });
-                
+
                 SetStatus($"Archived {movedCount} old version(s). Failed: {failedCount}");
                 
                 var message = $"Successfully archived {movedCount} old version package(s) to:\n{oldPackagesFolder}";

--- a/Windows/MainWindow.PackageOptimization.cs
+++ b/Windows/MainWindow.PackageOptimization.cs
@@ -106,24 +106,23 @@ namespace VPM
                 // MetadataKey is the actual filename from the metadata dictionary
                 string lookupKey = !string.IsNullOrEmpty(package.MetadataKey) ? package.MetadataKey : package.Name;
                 
-                // First check if package is in PackageManager metadata (handles external packages)
+                // First check PackageManager metadata for a direct FilePath
+                // (covers external packages, OffloadedVARs, and any non-standard location)
                 if (_packageManager?.PackageMetadata != null)
                 {
                     if (_packageManager.PackageMetadata.TryGetValue(lookupKey, out var metadata))
                     {
-                        // Check if it's an external package with a valid FilePath
-                        if (metadata.IsExternal && !string.IsNullOrEmpty(metadata.FilePath) && System.IO.File.Exists(metadata.FilePath))
+                        if (!string.IsNullOrEmpty(metadata.FilePath) && System.IO.File.Exists(metadata.FilePath))
                         {
                             return metadata.FilePath;
                         }
                     }
                 }
-                
+
                 // Try to get the package file info from standard locations
                 var fileInfo = _packageFileManager.GetPackageFileInfo(lookupKey);
                 if (fileInfo != null && !string.IsNullOrEmpty(fileInfo.CurrentPath))
                 {
-                    // Check if it's a .var file
                     if (System.IO.File.Exists(fileInfo.CurrentPath))
                     {
                         return fileInfo.CurrentPath;
@@ -1283,13 +1282,28 @@ namespace VPM
                 
 
                 string packagePath = pkgInfo.CurrentPath;
-                
+
                 // Only support VAR files
                 if (!packagePath.EndsWith(".var", StringComparison.OrdinalIgnoreCase))
                 {
-                    MessageBox.Show("Package optimization is only supported for .var files, not unarchived packages.", 
+                    MessageBox.Show("Package optimization is only supported for .var files, not unarchived packages.",
                                   "Unsupported Format", MessageBoxButton.OK, MessageBoxImage.Warning);
                     return;
+                }
+                // Determine BA-managed status early so dep inputs are gated before flag computation
+                string offloadedFolder = _settingsManager?.Settings?.BrowserAssistIntegration == true
+                    ? Services.BrowserAssistService.GetOffloadedVarsFolder(_selectedFolder)
+                    : null;
+                bool isInOffloadedVars = Services.BrowserAssistService.IsPathInOffloadedVars(packagePath, offloadedFolder);
+
+                // Gate dep inputs: BA-managed packages must not have their dependencies modified
+                if (isInOffloadedVars)
+                {
+                    disabledDependencies = new List<string>();
+                    latestConversionCount = 0;
+                    hasDependencyChanges = false;
+                    hasAnyChanges = selectedTextures.Count > 0 || selectedHairs.Count > 0 ||
+                                    selectedMirrors.Count > 0 || selectedLights.Count > 0;
                 }
 
                 // Check if package already has optimizations and if there are actual changes
@@ -1532,12 +1546,11 @@ namespace VPM
                     // Set mirrors flag
                     config.DisableMirrors = disableMirrors;
                     
-                    // Set force latest dependencies flag from settings
-                    config.ForceLatestDependencies = _settingsManager?.Settings?.ForceLatestDependencies ?? false;
-                    
-                    // Add disabled dependencies
+                    // Set dependency modifications (already gated for BA-managed packages after packagePath resolution)
+                    config.ForceLatestDependencies = !isInOffloadedVars &&
+                        (latestConversionCount > 0 || (_settingsManager?.Settings?.ForceLatestDependencies ?? false));
                     config.DisabledDependencies = disabledDependencies;
-                    
+
                     // Set disable morph preload flag from settings
                     config.DisableMorphPreload = _settingsManager?.Settings?.DisableMorphPreload ?? true;
                     
@@ -1570,8 +1583,8 @@ namespace VPM
                     texturesConverted = optimizationResult.TexturesConverted;
                     hairsModified = optimizationResult.HairsModified;
                     
-                    // Remove disabled dependencies if any
-                    if (disabledDependencies.Count > 0)
+                    // Remove disabled dependencies if any (skipped for BA-managed packages)
+                    if (!isInOffloadedVars && disabledDependencies.Count > 0)
                     {
                         await System.Threading.Tasks.Task.Run(() =>
                         {
@@ -2076,6 +2089,9 @@ namespace VPM
                 };
                 tabControl.Items.Add(summaryTab);
 
+                // Pre-compute BA state here so both the SelectionChanged and Loaded closures can capture it
+                bool isBaManaged = IsAnyPackageBaManaged(packages);
+
                 // Add SelectionChanged handler to refresh summary tab when selected
                 // This handler will be called after tabs are populated
                 tabControl.SelectionChanged += (s, e) =>
@@ -2085,7 +2101,7 @@ namespace VPM
                     if (selectedTab?.Header is string header && header == "Summary")
                     {
                         // Recreate summary tab content with current data
-                        var newSummaryTab = CreateBulkSummaryTab(packages, textureResult, hairResult, dependencyResult, dialog);
+                        var newSummaryTab = CreateBulkSummaryTab(packages, textureResult, hairResult, dependencyResult, dialog, isBaManaged);
                         selectedTab.Content = newSummaryTab.Content;
                     }
                 };
@@ -2388,7 +2404,7 @@ namespace VPM
                 };
                 
                 // Populate tabs after window is shown - use Dispatcher to ensure UI updates properly
-                dialog.Loaded += (s, e) => 
+                dialog.Loaded += (s, e) =>
                 {
                     updateTabWidths();
                     
@@ -2435,13 +2451,20 @@ namespace VPM
                             }
                             dependenciesTab = CreateBulkDependenciesTab(dependencyResult, _settingsManager?.Settings?.ForceLatestDependencies ?? false, dialog);
                             tabControl.Items.Insert(dependenciesIndex, dependenciesTab);
-                            
+
+                            if (isBaManaged)
+                            {
+                                dependenciesTab.IsEnabled = false;
+                                dependenciesTab.ToolTip = "Disabled while BrowserAssist is managing packages";
+                                ToolTipService.SetShowOnDisabled(dependenciesTab, true);
+                            }
+
                             int summaryIndex = tabControl.Items.Count > 5 ? 5 : tabControl.Items.Count;
                             if (tabControl.Items.Count > summaryIndex)
                             {
                                 tabControl.Items.RemoveAt(summaryIndex);
                             }
-                            summaryTab = CreateBulkSummaryTab(packages, textureResult, hairResult, dependencyResult, dialog);
+                            summaryTab = CreateBulkSummaryTab(packages, textureResult, hairResult, dependencyResult, dialog, isBaManaged);
                             tabControl.Items.Insert(summaryIndex, summaryTab);
                             
                             // Select the first tab (Textures)
@@ -2546,17 +2569,24 @@ namespace VPM
                 var mirrorsByPackage = hairResult.MirrorItems.Where(m => m.Disable == m.IsCurrentlyOn).GroupBy(m => m.PackageName).ToDictionary(g => g.Key, g => g.ToList());
                 var lightsByPackage = hairResult.LightItems.Where(l => l.HasActualShadowConversion).GroupBy(l => l.PackageName).ToDictionary(g => g.Key, g => g.ToList());
                 
-                // Group dependencies by package
-                var disabledDepsByPackage = dependencyResult?.Dependencies?.Where(d => !d.IsEnabled).GroupBy(d => d.PackageName).ToDictionary(g => g.Key, g => g.ToList()) ?? new Dictionary<string, List<DependencyItemModel>>();
-                
+                // BA-managed packages must not have their dependencies modified
+                bool baBatchManaged = IsAnyPackageBaManaged(packages);
+
+                // Group dependencies by package (empty when BA owns the batch)
+                var disabledDepsByPackage = !baBatchManaged
+                    ? dependencyResult?.Dependencies?.Where(d => !d.IsEnabled).GroupBy(d => d.PackageName).ToDictionary(g => g.Key, g => g.ToList()) ?? new Dictionary<string, List<DependencyItemModel>>()
+                    : new Dictionary<string, List<DependencyItemModel>>();
+
                 // Count dependencies that will be converted to .latest
                 // Include dependencies where ForceLatest is true AND they will be converted (not already .latest)
                 // Also check the global ForceLatestDependencies setting
-                bool forceLatestGlobalSetting = _settingsManager?.Settings?.ForceLatestDependencies ?? false;
-                var latestDepsToConvert = dependencyResult?.Dependencies?.Where(d => 
-                    d.IsEnabled && 
-                    (d.ForceLatest || forceLatestGlobalSetting) && 
-                    d.WillBeConvertedToLatest).ToList() ?? new List<DependencyItemModel>();
+                bool forceLatestGlobalSetting = !baBatchManaged && (_settingsManager?.Settings?.ForceLatestDependencies ?? false);
+                var latestDepsToConvert = !baBatchManaged
+                    ? dependencyResult?.Dependencies?.Where(d =>
+                        d.IsEnabled &&
+                        (d.ForceLatest || forceLatestGlobalSetting) &&
+                        d.WillBeConvertedToLatest).ToList() ?? new List<DependencyItemModel>()
+                    : new List<DependencyItemModel>();
                 var latestDepsByPackage = latestDepsToConvert.GroupBy(d => d.PackageName).ToDictionary(g => g.Key, g => g.ToList()) ?? new Dictionary<string, List<DependencyItemModel>>();
                 
                 // Also detect packages where dependencies have changed (including re-enabled dependencies)
@@ -3177,16 +3207,29 @@ namespace VPM
                 throw new Exception("Package optimization is only supported for .var files");
             }
 
+            // Determine BA-managed status early so dep inputs can be gated before flag computation
+            string coreOffloadedFolder = _settingsManager?.Settings?.BrowserAssistIntegration == true
+                ? Services.BrowserAssistService.GetOffloadedVarsFolder(_selectedFolder)
+                : null;
+            bool corePackageIsInOffloadedVars = Services.BrowserAssistService.IsPathInOffloadedVars(packagePath, coreOffloadedFolder);
+
+            // Gate dep inputs: BA-managed packages must not have their dependencies modified
+            if (corePackageIsInOffloadedVars)
+            {
+                disabledDependencies = null;
+                latestDependencies = null;
+            }
+
             // Check if package already has optimizations and if there are actual changes
             VarMetadata packageMetadata = null;
             if (_packageManager?.PackageMetadata != null)
             {
                 _packageManager.PackageMetadata.TryGetValue(packageName, out packageMetadata);
             }
-            
+
             bool isAlreadyOptimized = packageMetadata != null && packageMetadata.IsOptimized;
-            
-            // Check for dependency changes
+
+            // Check for dependency changes (already gated above for BA-managed packages)
             int disabledDepsCount = disabledDependencies?.Count ?? 0;
             int latestDepsCount = latestDependencies?.Count ?? 0;
             bool hasDependencyChanges = disabledDepsCount > 0 || latestDepsCount > 0;
@@ -3298,10 +3341,9 @@ namespace VPM
             // Set IsMorphAsset flag
             config.IsMorphAsset = packageMetadata?.IsMorphAsset ?? false;
             
-            // Set dependency modifications
-            // Check both the passed dependencies and the global setting
-            bool shouldForceLatest = latestDepsCount > 0 || (_settingsManager?.Settings?.ForceLatestDependencies ?? false);
-            config.ForceLatestDependencies = shouldForceLatest;
+            // Set dependency modifications (already gated for BA-managed packages at method entry)
+            config.ForceLatestDependencies = !corePackageIsInOffloadedVars &&
+                (latestDepsCount > 0 || (_settingsManager?.Settings?.ForceLatestDependencies ?? false));
             if (disabledDependencies != null)
             {
                 config.DisabledDependencies = disabledDependencies

--- a/Windows/MainWindow.UIManagement.cs
+++ b/Windows/MainWindow.UIManagement.cs
@@ -525,6 +525,11 @@ namespace VPM
             {
                 CheckForAppUpdatesMenuItem.IsChecked = settings.CheckForAppUpdates;
             }
+            // Update integrations menu items
+            if (BrowserAssistIntegrationMenuItem != null)
+            {
+                BrowserAssistIntegrationMenuItem.IsChecked = settings.BrowserAssistIntegration;
+            }
 
             if (!_settingsPropertyChangedHooked && settings != null)
             {
@@ -993,7 +998,8 @@ namespace VPM
                 List<string> installedFiles, availableFiles;
                 Dictionary<string, List<string>> externalFiles;
                 (installedFiles, availableFiles, externalFiles) = await _packageManager.ScanVarFilesWithExternalAsync(
-                    addonPackagesFolder, allPackagesFolder, externalDestinations);
+                    addonPackagesFolder, allPackagesFolder, externalDestinations,
+                    _settingsManager?.Settings?.BrowserAssistIntegration ?? false);
 
 
                 var externalCount = externalFiles.Values.Sum(l => l.Count);
@@ -1016,6 +1022,11 @@ namespace VPM
                 {
                     _reactiveFilterManager.Initialize(_packageManager.PackageMetadata);
                 }
+
+                // Refresh BA VAR management cache so button bar checks don't hit disk on every selection
+                _baVarManagementEnabled = _settingsManager?.Settings?.BrowserAssistIntegration == true
+                    ? Services.BrowserAssistService.IsVarManagementEnabled(_selectedFolder)
+                    : false;
 
                 // Copy preview image index from ImageManager
                 var totalImages = _imageManager.PreviewImageIndex.Values.Sum(list => list.Count);
@@ -2549,8 +2560,11 @@ namespace VPM
             {
                 if (!string.IsNullOrEmpty(_selectedFolder))
                 {
-                    _packageFileManager = new PackageFileManager(_selectedFolder, _imageManager);
-                    
+                    _packageFileManager = new PackageFileManager(_selectedFolder, _imageManager)
+                    {
+                        BrowserAssistIntegration = _settingsManager?.Settings?.BrowserAssistIntegration ?? false
+                    };
+
                     // Initialize package downloader
                     InitializePackageDownloader();
                 }

--- a/Windows/MainWindow.xaml
+++ b/Windows/MainWindow.xaml
@@ -387,6 +387,16 @@
                             <TextBlock FontSize="12" Text="" />
                         </MenuItem.Icon>
                     </MenuItem>
+                    
+                    <!--  Integrations Section  -->
+                    <MenuItem Header="🔌 _Integrations">
+                        <MenuItem
+                            x:Name="BrowserAssistIntegrationMenuItem"
+                            Click="ToggleBrowserAssistIntegration_Click"
+                            Header="_JayJayWon's BrowserAssist (BA) Integration"
+                            IsCheckable="True"
+                            ToolTip="Scan BA's OffloadedVARs folder so offloaded packages satisfy dependency checks, and clean up BA's cache when moving packages out of OffloadedVARs." />
+                    </MenuItem>
 
                     <Separator />
                     <MenuItem Click="SupportButton_Click" Header="❤️ _Support">
@@ -3645,6 +3655,7 @@
                                     FontSize="14"
                                     FontWeight="SemiBold"
                                     ToolTip="Load selected packages"
+                                    ToolTipService.ShowOnDisabled="True"
                                     Visibility="Collapsed">
                                     <Button.Style>
                                         <Style BasedOn="{StaticResource BlueHoverButtonStyle}" TargetType="Button">
@@ -3769,6 +3780,7 @@
                                     FontSize="14"
                                     FontWeight="SemiBold"
                                     ToolTip="Load selected packages and their dependencies"
+                                    ToolTipService.ShowOnDisabled="True"
                                     Visibility="Collapsed">
                                     <Button.Style>
                                         <Style BasedOn="{StaticResource BlueHoverButtonStyle}" TargetType="Button">
@@ -4484,6 +4496,7 @@
                                     FontSize="12"
                                     FontWeight="SemiBold"
                                     ToolTip="Load selected dependencies"
+                                    ToolTipService.ShowOnDisabled="True"
                                     Visibility="Collapsed">
                                     <Button.Style>
                                         <Style BasedOn="{StaticResource BlueHoverButtonStyle}" TargetType="Button">

--- a/Windows/MainWindow.xaml.cs
+++ b/Windows/MainWindow.xaml.cs
@@ -105,6 +105,9 @@ namespace VPM
         
         // Cache for dependents counts
         private Dictionary<string, int> _currentDependentsCounts = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
+        // Cached result of BA's VAR management enabled flag, refreshed after each package scan
+        private bool? _baVarManagementEnabled;
         
         private readonly object _customDependencyIndexLock = new object();
         

--- a/Windows/Optimizers/BulkOptimizationTabs.cs
+++ b/Windows/Optimizers/BulkOptimizationTabs.cs
@@ -1141,7 +1141,7 @@ namespace VPM
             return tab;
         }
 
-        private TabItem CreateBulkSummaryTab(List<PackageItem> packages, TextureValidator.ValidationResult textureResult, HairOptimizer.OptimizationResult hairResult, DependencyScanner.DependencyScanResult dependencyResult, Window parentDialog)
+        private TabItem CreateBulkSummaryTab(List<PackageItem> packages, TextureValidator.ValidationResult textureResult, HairOptimizer.OptimizationResult hairResult, DependencyScanner.DependencyScanResult dependencyResult, Window parentDialog, bool isBaManaged = false)
         {
             var tab = new TabItem
             {
@@ -1447,7 +1447,19 @@ namespace VPM
             };
             contentPanel.Children.Add(dependencyHeader);
 
-            if (dependencyResult != null && dependencyResult.Success)
+            if (isBaManaged)
+            {
+                var baText = new TextBlock
+                {
+                    Text = "  Disabled while BrowserAssist is managing packages",
+                    FontSize = 12,
+                    Foreground = new SolidColorBrush(Color.FromRgb(150, 150, 150)),
+                    FontStyle = FontStyles.Italic,
+                    Margin = new Thickness(15, 0, 0, 15)
+                };
+                contentPanel.Children.Add(baText);
+            }
+            else if (dependencyResult != null && dependencyResult.Success)
             {
                 var disabledDeps = dependencyResult.Dependencies.Where(d => !d.IsEnabled).ToList();
                 // Only count dependencies that will actually be changed (not already .latest)
@@ -1458,7 +1470,6 @@ namespace VPM
                 if (disabledDeps.Count > 0 || forceLatestDeps.Count > 0)
                 {
                     var depInfoPanel = new StackPanel { Margin = new Thickness(15, 0, 0, 15) };
-                    
                     if (disabledDeps.Count > 0)
                     {
                         var disabledDepsByPackage = disabledDeps.GroupBy(d => d.PackageName).OrderBy(g => g.Key);
@@ -1471,7 +1482,7 @@ namespace VPM
                         };
                         depInfoPanel.Children.Add(disabledCountText);
                     }
-                    
+
                     if (forceLatestDeps.Count > 0)
                     {
                         var forceLatestDepsByPackage = forceLatestDeps.GroupBy(d => d.PackageName).OrderBy(g => g.Key);
@@ -1484,7 +1495,7 @@ namespace VPM
                         };
                         depInfoPanel.Children.Add(forceLatestCountText);
                     }
-                    
+
                     contentPanel.Children.Add(depInfoPanel);
                 }
                 else


### PR DESCRIPTION
Adds support for BrowserAssist (BA), a VaM plugin that offloads packages to a separate `OffloadedVARs/` folder. VPM now recognizes these packages, includes them in dependency checks, and prevents operations that could corrupt BA's cache.

The integration was mentioned as a feature request in #15. 

Tag awareness (the first idea) is not part of this PR, as it would require deeper integration with BA's internal tagging system (But is definitely doable).

This PR implements the second idea (two-way awareness of BA's VAR management), so offloaded packages are visible, counted in dependency checks, and protected from operations that would corrupt BA's cache. 



---
### What's new
- **BrowserAssistService**: detects BA installation by checking if the `OffloadedVARs/` folder exists, additionally reads BA's config to confirm VAR management is active, and provides helpers for checking whether a package is BA-managed
   - If it isn't enabled, you will see this popup:
- **Package scanning**: `OffloadedVARs/` is scanned alongside the existing three folders; offloaded packages appear with "Available" status and are included in the status index and dependency graph
- **Load/move blocking**: packages managed by BA cannot be loaded or moved through VPM, preventing file conflicts that cause BA cache corruption
   - Dependency modification tabs in the bulk optimizer are disabled for BA-managed packages
   - Also added tooltips on hover to explain why the buttons can't be clicked
- **Duplicate management**: a new "OffloadedVars (BA)" column appears in the duplicate window when the integration is active

<img width="886" height="593" alt="image" src="https://github.com/user-attachments/assets/dbe4c317-3a1b-4b1d-9831-334f3c864ee1" />
<img width="436" height="220" alt="ZNwwDQRNfS" src="https://github.com/user-attachments/assets/5c3b3e7c-f5ba-439b-9154-6bad6cb47a2e" />

---

### Setup dialog 
First-time enable shows an overview of what the integration enables and disables, with an explanation of why the restrictions exist

<img width="640" height="820" alt="image" src="https://github.com/user-attachments/assets/b704fdd3-60b1-4a41-a6d8-be624ad38945" />

### Settings toggle
 On/off switch under a new "Integrations" menu, persisted in AppSettings
<img width="548" height="335" alt="image" src="https://github.com/user-attachments/assets/abafa1d1-cb3c-4915-ba99-0da689c25fc4" />

---

### What remains enabled in the VPM core

  - Offloaded packages show up in your list as "Available"
  - Dependency checks count offloaded packages
  - BA's cache is cleaned up when you archive packages
  - Optimization features work as normal, with the exception of dependency forcing
  - Duplicate handling, a new column is visible after enabling the integration
  - Archiving packages. This also removes the package from BrowserAssist's "memory"

### What's restricted (and why)

BA and VPM both move `.var` files around. If VPM moves a file that BA is tracking, BA's internal cache becomes stale, which can cause broken presets, scenes, et cetera. From personal experience, it's not fun seeing the eyes pop out and the fingers become tree branches because the package is modified without BA picking up on it. Letting VPM handle it, will eventually force a full cache rescan in VaM. This is known to cause heap errors, crashes, and tedious fixing due to how limited VaM is with big file operations. 

To avoid this, VPM operates in a safe read-only mode for any package inside `OffloadedVARs/`:

- Load/unload/move operations are blocked with a user-facing message
- Dependency forcing in the optimizer is disabled
- BA companion files (`.json` sidecars) are cleaned up when archiving
<img width="1973" height="760" alt="FolderChangesView_4wk3CODkui" src="https://github.com/user-attachments/assets/e54a2da3-e862-4ebb-bec8-5c9794d70582" />

---
### Commits

- `0d407bf` feat: add BrowserAssistService for BA plugin integration
- `0eb0282` feat: add BA integration toggle in settings and Integrations menu
- `f4e0203` feat: scan OffloadedVARs during package scan and include in status index
- `cb5523e` feat: block load/move operations for BA-managed packages
- `ef9c009` feat: BA integration toggle handler, context menu gating, and duplicate window wiring
- `9c81b22` feat: gate dependency modifications in optimizer for BA-managed packages
- `fe6aa24` feat: add OffloadedVars column to duplicate management window
- `5a24be7` feat: add first-time BA setup dialog with integration overview
- `289619e` chore: remove hardcoded workingDirectory from launchSettings to avoid debug build errors in VS
- `d5615be` fix: add missing RowDefinition in BA setup dialog causing overlapping bullet points

### QA performed

- [x] Enable BA integration with a valid VaM+BA installation; verify OffloadedVARs packages appear as "Available"
- [x] Verify dependency checks count offloaded packages (a package whose only dependency is in OffloadedVARs should not show as missing)
- [x] Try to load/move a BA-managed package; confirm it is blocked with an informative message
- [x] Open the optimizer on a BA-managed package; confirm dependency tabs are disabled
- [x] Open duplicate management with BA active; confirm the OffloadedVars column appears and selections work
- [x] Disable BA integration; verify offloaded packages disappear from the list and the duplicate column hides
- [x] Disable BA integration; verify application works as normal
- [x] Archive a package that has BA companion files; verify `.json` sidecars are cleaned up


> [!NOTE]
> This solution is NOT tested towards [VPB](https://github.com/gicstin/VPB), but should not interfere with it's processes at all (The two have the same purpose, having them both manage at the same time is smoothbrain anyways) 
