### PR TITLE
Fix Scenes filter dropping large packages; update SharpCompress to 0.49.1

### DIFF
--- a/Services/BinaryMetadataCache.cs
+++ b/Services/BinaryMetadataCache.cs
@@ -15,7 +15,7 @@ namespace VPM.Services
     /// </summary>
     public class BinaryMetadataCache : IDisposable
     {
-        private const int CACHE_VERSION = 14; // Removed ContentList and AllFiles from cache payload
+        private const int CACHE_VERSION = 15; // Categories now detected from full content list (was capped at 100)
         private readonly string _cacheFilePath;
         private readonly string _cacheDirectory;
         private readonly Dictionary<string, CachedMetadata> _cache = new(StringComparer.OrdinalIgnoreCase);

--- a/Services/DependencyRemover.cs
+++ b/Services/DependencyRemover.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -62,11 +62,8 @@ namespace VPM.Services
             try
             {
                 using (var sourceArchive = SharpCompressHelper.OpenForRead(varPath))
-                using (var destArchive = ZipArchive.Create())
+                using (var destArchive = ZipArchive.CreateArchive())
                 {
-                    // Set maximum compression level for smaller output files
-                    destArchive.DeflateCompressionLevel = SharpCompress.Compressors.Deflate.CompressionLevel.BestCompression;
-                    
                     foreach (var entry in sourceArchive.Entries)
                     {
                         if (entry.Key.Equals("meta.json", StringComparison.OrdinalIgnoreCase))
@@ -87,7 +84,8 @@ namespace VPM.Services
                     // Save the archive inside the using block
                     using (var destFileStream = new FileStream(tempPath, FileMode.Create, FileAccess.Write, FileShare.None))
                     {
-                        destArchive.SaveTo(destFileStream, CompressionType.Deflate);
+                        // BestCompression for smaller output; level lives on ZipWriterOptions in SharpCompress 0.49+
+                        destArchive.SaveTo(destFileStream, new SharpCompress.Writers.Zip.ZipWriterOptions(CompressionType.Deflate, SharpCompress.Compressors.Deflate.CompressionLevel.BestCompression));
                     }
                 }
 

--- a/Services/OptimizedVarScanner.cs
+++ b/Services/OptimizedVarScanner.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -72,7 +72,7 @@ namespace VPM.Services
                 result.FileSize = fileInfo.Length;
                 result.LastWriteTime = fileInfo.LastWriteTimeUtc;
 
-                using (var zipFile = ZipArchive.Open(varPath))
+                using (var zipFile = ZipArchive.OpenArchive(varPath))
                 {
                     var indexedEntries = new List<VarFileEntry>();
                     var pairedFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -288,7 +288,7 @@ namespace VPM.Services
                 {
                     if (_archive == null && !_disposed)
                     {
-                        _archive = ZipArchive.Open(_varPath);
+                        _archive = ZipArchive.OpenArchive(_varPath);
                     }
                 }
             }

--- a/Services/PackageManager.cs
+++ b/Services/PackageManager.cs
@@ -867,7 +867,9 @@ namespace VPM.Services
                 return categories.ToArray();
             }
             
-            foreach (var content in contentList.Take(100))
+            // Scan the full list, not a prefix: large packages (e.g. TGC scene packs) bundle hundreds of
+            // support assets ahead of their scene files in archive order, so a cap would miss "Scenes".
+            foreach (var content in contentList)
             {
                 var category = DetectCategoryFromPath(content);
                 if (!string.IsNullOrEmpty(category) && category != "Unknown")

--- a/Services/PackageRepackager.cs
+++ b/Services/PackageRepackager.cs
@@ -601,10 +601,8 @@ namespace VPM.Services
                                 File.Delete(tempOutputPath);
                             }
 
-                            using (var outputArchive = ZipArchive.Create())
+                            using (var outputArchive = ZipArchive.CreateArchive())
                             {
-                                outputArchive.DeflateCompressionLevel = SharpCompress.Compressors.Deflate.CompressionLevel.BestCompression;
-
                                 foreach (var entry in archive.Archive.Entries)
                                 {
                                     if (entry.Key.Equals("meta.json", StringComparison.OrdinalIgnoreCase))
@@ -622,7 +620,8 @@ namespace VPM.Services
 
                                 using (var outputFileStream = new FileStream(tempOutputPath, FileMode.Create, FileAccess.Write, FileShare.None))
                                 {
-                                    outputArchive.SaveTo(outputFileStream, CompressionType.Deflate);
+                                    // BestCompression for smaller output; level lives on ZipWriterOptions in SharpCompress 0.49+
+                                    outputArchive.SaveTo(outputFileStream, new SharpCompress.Writers.Zip.ZipWriterOptions(CompressionType.Deflate, SharpCompress.Compressors.Deflate.CompressionLevel.BestCompression));
                                 }
                             }
                         }
@@ -690,11 +689,8 @@ namespace VPM.Services
                     // Use forceGcOnDispose to ensure file handles are released before we try to delete/replace
                     using (var sourceArchive = SharpCompressHelper.OpenForReadInternal(sourcePathForProcessing, forceGcOnDispose: true))
                     using (var outputMemoryStream = new MemoryStream())
-                    using (var outputArchive = ZipArchive.Create())
+                    using (var outputArchive = ZipArchive.CreateArchive())
                     {
-                        // Set maximum compression level for smaller output files
-                        outputArchive.DeflateCompressionLevel = SharpCompress.Compressors.Deflate.CompressionLevel.BestCompression;
-                        
                         string originalMetaJson = null;
                         DateTime? originalMetaJsonDate = null;
                         object archiveLock = new object();
@@ -1380,7 +1376,7 @@ namespace VPM.Services
                         
                         // Save the archive to the memory stream with Deflate compression for game compatibility
                         // Note: Most content is already compressed (PNG, JPG, etc.), so performance impact is minimal
-                        outputArchive.SaveTo(outputMemoryStream, SharpCompress.Common.CompressionType.Deflate);
+                        outputArchive.SaveTo(outputMemoryStream, new SharpCompress.Writers.Zip.ZipWriterOptions(SharpCompress.Common.CompressionType.Deflate, SharpCompress.Compressors.Deflate.CompressionLevel.BestCompression));
                         
                         _performanceTimer.Stop("Archive Writing - Compression & Save");
                         _performanceTimer.Start("Archive Writing - File Write");

--- a/Services/ParallelArchiveProcessor.cs
+++ b/Services/ParallelArchiveProcessor.cs
@@ -48,7 +48,7 @@ namespace VPM.Services
             
             // One archive per thread via ThreadLocal.
             using var threadLocalArchive = new ThreadLocal<IArchive>(
-                () => ZipArchive.Open(zipPath), 
+                () => ZipArchive.OpenArchive(zipPath), 
                 trackAllValues: true);
 
             try
@@ -117,7 +117,7 @@ namespace VPM.Services
 
             // ThreadLocal opens ONE archive per thread instead of per item (10-50x faster)
             using var threadLocalArchive = new ThreadLocal<IArchive>(
-                () => ZipArchive.Open(zipPath), 
+                () => ZipArchive.OpenArchive(zipPath), 
                 trackAllValues: true);
 
             try
@@ -193,7 +193,7 @@ namespace VPM.Services
 
             // ThreadLocal opens ONE archive per thread instead of per item (10-50x faster)
             using var threadLocalArchive = new ThreadLocal<IArchive>(
-                () => ZipArchive.Open(zipPath), 
+                () => ZipArchive.OpenArchive(zipPath), 
                 trackAllValues: true);
 
             try

--- a/Services/SceneScanner.cs
+++ b/Services/SceneScanner.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
@@ -78,7 +78,7 @@ namespace VPM.Services
 
                 // Get all scene entries first
                 List<IArchiveEntry> sceneEntries = new List<IArchiveEntry>();
-                using (var zipFile = ZipArchive.Open(varPath))
+                using (var zipFile = ZipArchive.OpenArchive(varPath))
                 {
                     var allEntries = SharpCompressHelper.GetAllEntries(zipFile);
                     // Look for scene files in Saves/scene/ path
@@ -190,7 +190,7 @@ namespace VPM.Services
             // Try to parse metadata from VAR entry
             try
             {
-                using (var zipFile = ZipArchive.Open(varPath))
+                using (var zipFile = ZipArchive.OpenArchive(varPath))
                 {
                     var jsonContent = SharpCompressHelper.ReadEntryAsString(zipFile, entry);
                     var metadata = ParseSceneMetadataFromJson(jsonContent);
@@ -233,7 +233,7 @@ namespace VPM.Services
             // Try to parse metadata from VAR entry
             try
             {
-                using (var zipFile = ZipArchive.Open(varPath))
+                using (var zipFile = ZipArchive.OpenArchive(varPath))
                 {
                     // Re-find the entry in the new ZipFile instance
                     var entryInZip = SharpCompressHelper.FindEntryByPath(zipFile, entry.Key);
@@ -280,7 +280,7 @@ namespace VPM.Services
         {
             try
             {
-                using (var zipFile = ZipArchive.Open(varPath))
+                using (var zipFile = ZipArchive.OpenArchive(varPath))
                 {
                     var basePath = Path.ChangeExtension(sceneEntryPath, null);
                     var extensions = new[] { ".jpg", ".jpeg", ".png", ".JPG", ".JPEG", ".PNG" };
@@ -586,7 +586,7 @@ namespace VPM.Services
 
                 // Extract thumbnail from VAR using streaming
                 // Benefit: Efficient memory usage for thumbnail extraction
-                using (var zipFile = ZipArchive.Open(varPath))
+                using (var zipFile = ZipArchive.OpenArchive(varPath))
                 {
                     var entry = SharpCompressHelper.FindEntryByPath(zipFile, entryPath);
                     if (entry != null)

--- a/Services/SharpCompressHelper.cs
+++ b/Services/SharpCompressHelper.cs
@@ -113,7 +113,7 @@ namespace VPM.Services
                     try
                     {
                         fileStream = new FileStream(_archivePath, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, useAsync: false);
-                        var archive = ZipArchive.Open(fileStream);
+                        var archive = ZipArchive.OpenArchive(fileStream);
                         fileStream = null; // Archive now owns the stream
                         
                         // Track the handle
@@ -172,7 +172,7 @@ namespace VPM.Services
                     try
                     {
                         fileStream = new FileStream(_archivePath, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, useAsync: false);
-                        var archive = ZipArchive.Open(fileStream);
+                        var archive = ZipArchive.OpenArchive(fileStream);
                         fileStream = null; // Archive now owns the stream
                         
                         // Track the handle
@@ -316,7 +316,7 @@ namespace VPM.Services
                 
                 // Open file with explicit seek support (FileAccess.Read, FileShare.Read)
                 fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, useAsync: false);
-                var archive = ZipArchive.Open(fileStream);
+                var archive = ZipArchive.OpenArchive(fileStream);
                 fileStream = null; // Archive now owns the stream
                 
                 // Pass the read lock to DisposableArchive - it will release the lock when disposed
@@ -350,7 +350,7 @@ namespace VPM.Services
             {
                 // Open file with explicit seek support (FileAccess.Read, FileShare.Read)
                 fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, useAsync: false);
-                var archive = ZipArchive.Open(fileStream);
+                var archive = ZipArchive.OpenArchive(fileStream);
                 fileStream = null; // Archive now owns the stream
                 
                 // No read lock - caller is responsible for ensuring exclusive access
@@ -368,7 +368,7 @@ namespace VPM.Services
         /// </summary>
         public static IArchive OpenStreamForRead(Stream stream)
         {
-            return ZipArchive.Open(stream);
+            return ZipArchive.OpenArchive(stream);
         }
 
         /// <summary>
@@ -380,7 +380,7 @@ namespace VPM.Services
             {
                 // Create and return a new archive
                 // Note: The archive will be saved to the file path when SaveTo() is called
-                return ZipArchive.Create();
+                return ZipArchive.CreateArchive();
             }
             catch (Exception ex)
             {
@@ -395,7 +395,7 @@ namespace VPM.Services
         {
             // Create a new archive that can be written to the provided stream
             // The caller should use SaveTo(stream) to write the archive
-            return ZipArchive.Create();
+            return ZipArchive.CreateArchive();
         }
 
         /// <summary>
@@ -408,7 +408,7 @@ namespace VPM.Services
             {
                 // Open file with explicit seek support (FileAccess.ReadWrite, FileShare.None for exclusive access)
                 fileStream = new FileStream(filePath, FileMode.Open, FileAccess.ReadWrite, FileShare.None, 4096, useAsync: false);
-                var archive = ZipArchive.Open(fileStream);
+                var archive = ZipArchive.OpenArchive(fileStream);
                 fileStream = null; // Archive now owns the stream
                 return archive;
             }

--- a/Services/TextureValidator.cs
+++ b/Services/TextureValidator.cs
@@ -426,7 +426,7 @@ namespace VPM.Services
                 // For VAR files: Open archive ONCE and process all textures (10-50x faster)
                 if (isVarFile)
                 {
-                    using (var archive = ZipArchive.Open(packagePath))
+                    using (var archive = ZipArchive.OpenArchive(packagePath))
                     {
                         // Build entry lookup dictionary for O(1) access instead of O(n) per texture
                         var entryLookup = new Dictionary<string, IArchiveEntry>(StringComparer.OrdinalIgnoreCase);
@@ -682,7 +682,7 @@ namespace VPM.Services
             bool exists = false;
             if (isVarFile)
             {
-                using (var zipFile = ZipArchive.Open(packagePath))
+                using (var zipFile = ZipArchive.OpenArchive(packagePath))
                 {
                     exists = SharpCompressHelper.FindEntryByPath(zipFile, texturePath) != null;
                 }
@@ -861,7 +861,7 @@ namespace VPM.Services
             {
                 if (isVarFile)
                 {
-                    using (var zipFile = ZipArchive.Open(packagePath))
+                    using (var zipFile = ZipArchive.OpenArchive(packagePath))
                     {
                         var metaEntry = SharpCompressHelper.FindEntryByPath(zipFile, "meta.json");
                         if (metaEntry != null)
@@ -989,7 +989,7 @@ namespace VPM.Services
                 
                 if (isVarFile)
                 {
-                    using (var zipFile = ZipArchive.Open(packagePath))
+                    using (var zipFile = ZipArchive.OpenArchive(packagePath))
                     {
                         var entry = SharpCompressHelper.FindEntryByPath(zipFile, texturePath);
                         if (entry != null)
@@ -1074,7 +1074,7 @@ namespace VPM.Services
                     
                     if (isVarFile)
                     {
-                        using (var zipFile = ZipArchive.Open(packagePath))
+                        using (var zipFile = ZipArchive.OpenArchive(packagePath))
                         {
                             var entry = SharpCompressHelper.FindEntryByPath(zipFile, texturePath);
                             if (entry != null)
@@ -1192,7 +1192,7 @@ namespace VPM.Services
 
                 if (isVarFile)
                 {
-                    using (var zipFile = ZipArchive.Open(packagePath))
+                    using (var zipFile = ZipArchive.OpenArchive(packagePath))
                     {
                         var entry = SharpCompressHelper.FindEntryByPath(zipFile, texturePath);
                         if (entry != null)
@@ -1465,7 +1465,7 @@ namespace VPM.Services
             
             try
             {
-                using (var zipFile = ZipArchive.Open(archivePackagePath))
+                using (var zipFile = ZipArchive.OpenArchive(archivePackagePath))
                 {
                     var allEntries = SharpCompressHelper.GetAllEntries(zipFile);
                     foreach (var entry in allEntries)
@@ -1511,7 +1511,7 @@ namespace VPM.Services
             
             try
             {
-                using (var zipFile = ZipArchive.Open(archivePackagePath))
+                using (var zipFile = ZipArchive.OpenArchive(archivePackagePath))
                 {
                     var allEntries = SharpCompressHelper.GetAllEntries(zipFile);
                     foreach (var entry in allEntries)

--- a/Services/VarRepackager.cs
+++ b/Services/VarRepackager.cs
@@ -208,11 +208,8 @@ namespace VPM.Services
                     // Open source VAR (from archive or after moving to archive)
                     // NOTE: Use OpenForReadInternal because we already hold the write lock
                     using (var sourceArchive = SharpCompressHelper.OpenForReadInternal(sourcePathForProcessing))
-                    using (var outputArchive = ZipArchive.Create())
+                    using (var outputArchive = ZipArchive.CreateArchive())
                     {
-                        // Set maximum compression level for smaller output files
-                        outputArchive.DeflateCompressionLevel = SharpCompress.Compressors.Deflate.CompressionLevel.BestCompression;
-                        
                         string originalMetaJson = null;
 
                         var allEntries = sourceArchive.Entries.ToList();
@@ -345,7 +342,8 @@ namespace VPM.Services
 
                         using (var outputFileStream = new FileStream(tempOutputPath, FileMode.Create, FileAccess.Write, FileShare.None))
                         {
-                            outputArchive.SaveTo(outputFileStream, CompressionType.Deflate);
+                            // BestCompression for smaller output; level lives on ZipWriterOptions in SharpCompress 0.49+
+                            outputArchive.SaveTo(outputFileStream, new SharpCompress.Writers.Zip.ZipWriterOptions(CompressionType.Deflate, SharpCompress.Compressors.Deflate.CompressionLevel.BestCompression));
                         }
                     }
                     

--- a/Services/VirtualArchiveCache.cs
+++ b/Services/VirtualArchiveCache.cs
@@ -182,7 +182,7 @@ namespace VPM.Services
                 // Read directory structure only - no file data yet
                 // File is opened and closed within this block
                 using (var fileStream = new FileStream(FilePath, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, useAsync: false))
-                using (var archive = ZipArchive.Open(fileStream))
+                using (var archive = ZipArchive.OpenArchive(fileStream))
                 {
                     foreach (var entry in archive.Entries)
                     {
@@ -323,7 +323,7 @@ namespace VPM.Services
                 // Read ONLY the requested entry - file is opened and closed within this block
                 // The archive is NOT fully loaded into memory - only the specific entry is decompressed
                 using (var fileStream = new FileStream(FilePath, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, useAsync: false))
-                using (var archive = ZipArchive.Open(fileStream))
+                using (var archive = ZipArchive.OpenArchive(fileStream))
                 {
                     var archiveEntry = archive.Entries.FirstOrDefault(e => 
                         e.Key.Equals(path, StringComparison.OrdinalIgnoreCase));
@@ -462,7 +462,7 @@ namespace VPM.Services
                 
                 // SINGLE file open for ALL requested entries
                 using (var fileStream = new FileStream(FilePath, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, useAsync: false))
-                using (var archive = ZipArchive.Open(fileStream))
+                using (var archive = ZipArchive.OpenArchive(fileStream))
                 {
                     var pathSet = new HashSet<string>(uncachedPaths, StringComparer.OrdinalIgnoreCase);
                     

--- a/VPM.csproj
+++ b/VPM.csproj
@@ -37,7 +37,7 @@
     <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2903.40" />
     <PackageReference Include="NetVips" Version="3.1.0" />
     <PackageReference Include="NetVips.Native" Version="8.17.3" />
-    <PackageReference Include="SharpCompress" Version="0.37.2" />
+    <PackageReference Include="SharpCompress" Version="0.49.1" />
   </ItemGroup>
   
   <ItemGroup>


### PR DESCRIPTION
### Two related changes:

1. Fixes the Scenes content-type filter excluding packages that clearly contain scenes (Reported in Discord, essentially a feature request seen as a bug due to them not knowing it stops at 100)
2. Updates SharpCompress 0.37.2 to 0.49.1 to clear security vulnerabilities in the older version, and migrates the code to its new archive API.

They ship together because the build does not compile on 0.49.1 without the API migration, so the filter fix cannot be tested in isolation on this branch.

### The lack
Filtering by creator `TGC` shows 119 packages. Adding the `Scenes` content-type filter drops that to 21, hiding packages that obviously contain scenes (all 11 versions of `TGC.Scene_VirtualSweetheartReLoaded.##`, for example). The package info panel still reports a non-zero scene count for the hidden packages, which is the tell that detection and filtering disagree.

### Root cause
The Scenes filter matches against each package's detected `Categories`. That array is built by `DetectCategoriesFromContent`, which only inspected the first 100 relevant entries of the archive:

```csharp
foreach (var content in contentList.Take(100))
```

Large scenes like this one bundles a heap of stuff. The scan hit its 100-entry cap before it reached the scene, so `Categories` got `Clothing` / `Hair` / `Textures` but never `Scenes`.


### The fix
Scan the full content list instead of the first 100 entries. The full list is already iterated twice immediately afterward (`DetectMorphAsset`, `CountContentItems`), so the extra cost is negligible, and category detection now agrees with the counts by construction. This also corrects a latent undercount for Hair, Clothing, and other categories on any large package, not just Scenes.

The binary metadata cache version is bumped 14 to 15 so existing installs discard their stale `Categories` and re-detect on the next launch. That first launch triggers a one-time full rescan, which can take a while, especially now that the final build is larger.

### SharpCompress 0.49.1
Updated from 0.37.2 to remediate security vulnerabilities reported against the older releases. The 0.49 line renamed its archive factory API, so the migration covers:
- `ZipArchive.Open` to `ZipArchive.OpenArchive` and `ZipArchive.Create` to `ZipArchive.CreateArchive` (33 call sites).
- Deflate compression level moved off the archive object onto `ZipWriterOptions`, now passed to `SaveTo`. Existing `BestCompression` behavior is preserved explicitly, so output is not silently downgraded to the default level.

Bonus: 0.49 compresses noticeably better than 0.37, so repackaged `.var` files come out smaller. (Upto 88% on Caelryn packages when compressing 8k --> 4k!!)
